### PR TITLE
ENH: Add support for building against VTK >= 8.90

### DIFF
--- a/CMake/vtkWrapHierarchy.cmake
+++ b/CMake/vtkWrapHierarchy.cmake
@@ -5,6 +5,8 @@ macro(VTK_WRAP_HIERARCHY module_name OUTPUT_DIR SOURCES)
   if(NOT VTK_WRAP_HIERARCHY_EXE)
     if(TARGET vtkWrapHierarchy)
       set(VTK_WRAP_HIERARCHY_EXE vtkWrapHierarchy)
+    elseif(TARGET VTK::WrapHierarchy)
+      set(VTK_WRAP_HIERARCHY_EXE VTK::WrapHierarchy)
     else()
       message(SEND_ERROR "VTK_WRAP_HIERARCHY_EXE not specified when calling VTK_WRAP_HIERARCHY")
     endif()
@@ -87,9 +89,16 @@ $<$<BOOL:$<TARGET_PROPERTY:${module_name},INCLUDE_DIRECTORIES>>:
       # add to the INPUT_FILES
       list(APPEND INPUT_FILES ${TMP_INPUT})
 
+      set(_name ${module_name})
+      if(${VTK_VERSION} VERSION_GREATER_EQUAL "8.90")
+        if(VTK_ENABLE_KITS AND ${_name}_KIT)
+          set(_name "${${_name}_KIT}Kit")
+        endif()
+      endif()
+
       # add the info to the init file
       set(VTK_WRAPPER_INIT_DATA
-        "${VTK_WRAPPER_INIT_DATA}${TMP_INPUT};${module_name}")
+        "${VTK_WRAPPER_INIT_DATA}${TMP_INPUT};${_name}")
 
       set(VTK_WRAPPER_INIT_DATA "${VTK_WRAPPER_INIT_DATA}\n")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ include(vtkAddonFunctionAddExecutable)
 # VTK
 #
 find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
+if(${VTK_VERSION} VERSION_LESS "8.90")
+  include(${VTK_USE_FILE})
+endif()
 set(vtkAddon_LIBS ${VTK_LIBRARIES})
 
 # --------------------------------------------------------------------------
@@ -215,11 +217,16 @@ if(vtkAddon_WRAP_PYTHON)
     KIT_MODULE_INSTALL_LIB_DIR ${${PROJECT_NAME}_INSTALL_PYTHON_MODULE_LIB_DIR}
     )
   # Export target
-  export(TARGETS ${lib_name}Python ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  export(TARGETS ${lib_name}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  endif()
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
-    set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    endif()
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()


### PR DESCRIPTION
This commit updates wrapping infrastructure to support VTK >= 8.90:

* Support wrapping of VTK based classes independently of the version
  of VTK being used, a custom copy of vtkWrapHierarchy, vtkWrapPython and
  vtkWrapperInit.data.in have been added.

* With VTK >= 8.90, merge Python with PythonD libraries

* Update vtkWrapPython to make sure remote modules targets are ignored when wrapping
  Slicer classes.

* Update VTK wrapping CMake modules to ensure hierarchy files of dependencies are
  passed to both vtkWrapHierarchy and vtkWrapPython tools using the --types parameter.

  See See https://discourse.vtk.org/t/issue-with-using-vtkpythonutil-getobjectfrompointer-for-custom-vtk-classes/4100

  VTK has also been updated to disable the relative import generated in the
  "*InitImpl.cxx" files. It led to the generation of code similar to the following
  which was failing when trying to perform the relative import of Slicer wrapped
  modules using "vtkPythonUtil::ImportModule":

    const char *depends[4] = {
      "vtkAddonPython",
      "vtkITKPython",
      "vtkSegmentationCorePython",
      "vtkTeemPython",
    };

    for (int i = 0; i < 4; i++)
    {
      if (!vtkPythonUtil::ImportModule(depends[i], d))
      {
        return PyErr_Format(PyExc_ImportError,
          "Failed to load MRMLCorePython: No module named %s",
          depends[i]);
      }
    }

* Fix slicer.util.importModuleObjects to work with VTK >- 8.90

  Since python module generated using VTK>=8.90 already take care
  of importing their dependencies using `vtkPythonUtil::ImportModule`, the
  sys.modules dict is updated early on.

  To accomodate this, this commit changes the test checking if items
  of an object have already been imported into the target one.

Co-authored-by: Andras Lasso <lasso@queensu.ca>
Co-authored-by: David Gobbi <david.gobbi@gmail.com>