### PR TITLE
COMP: Fix configuration for VTK with external HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13.4)
 #-----------------------------------------------------------------------------
 
 project(vtkAddon
-  LANGUAGES CXX
+  LANGUAGES CXX C
   DESCRIPTION "General-purpose features that may be integrated into VTK library in the future."
 )
 


### PR DESCRIPTION
This commit fixes the configuration of vtkAddon when built against VTK
with external HDF5 library. This closes #14.