### PR TITLE
ENH: Add vtkParallelTransportFrame class for robust computation of curve coordinate system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ set(vtkAddon_SRCS
   vtkAddonMathUtilities.h
   vtkAddonMathUtilities.cxx
   vtkAddonSetGet.h
+  vtkParallelTransportFrame.cxx
+  vtkParallelTransportFrame.h
   vtkStreamingVolumeCodec.cxx
   vtkStreamingVolumeCodec.h
   vtkStreamingVolumeFrame.cxx

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -4,6 +4,7 @@ create_test_sourcelist(Tests ${KIT}CxxTests.cxx
   vtkAddonMathUtilitiesTest1.cxx
   vtkAddonTestingUtilitiesTest1.cxx
   vtkLoggingMacrosTest1.cxx
+  vtkParallelTransportTest1.cxx
   vtkPersonInformationTest1.cxx
   )
 

--- a/Testing/vtkParallelTransportTest1.cxx
+++ b/Testing/vtkParallelTransportTest1.cxx
@@ -1,0 +1,137 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// vtkAddon includes
+#include <vtkAddonTestingMacros.h>
+#include <vtkParallelTransportFrame.h>
+
+// VTK includes
+#include <vtkArcSource.h>
+#include <vtkDoubleArray.h>
+#include <vtkLineSource.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+
+//----------------------------------------------------------------------------
+int vtkParallelTransportTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
+{
+  vtkNew<vtkParallelTransportFrame> parallelTransportFrame;
+  double tolerance = 1e-3;
+  bool verbose = false;
+
+  // Test computation with a straight line input (zero curvature)
+
+  double lineDirection[3] = { 0.0, 0.0, 1.0 };
+  vtkNew<vtkLineSource> line;
+  line->SetPoint1(10,20,30);
+  line->SetPoint1(30,70,-80);
+  line->SetResolution(10);
+  parallelTransportFrame->SetInputConnection(line->GetOutputPort());
+  parallelTransportFrame->Update();
+
+  {
+    vtkPointData* pointData = parallelTransportFrame->GetOutput()->GetPointData();
+    vtkDoubleArray* normalsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Normals"));
+    vtkDoubleArray* binormalsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Binormals"));
+    vtkDoubleArray* tangentsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Tangents"));
+    CHECK_NOT_NULL(normalsArray);
+    CHECK_NOT_NULL(binormalsArray);
+    CHECK_NOT_NULL(tangentsArray);
+    for (vtkIdType tupleIndex = 0; tupleIndex < normalsArray->GetNumberOfTuples(); tupleIndex++)
+      {
+      double* v = normalsArray->GetTuple3(tupleIndex);
+      CHECK_DOUBLE_TOLERANCE(v[0], 0.963584, tolerance);
+      CHECK_DOUBLE_TOLERANCE(v[1], -0.176089, tolerance);
+      CHECK_DOUBLE_TOLERANCE(v[2], 0.201244, tolerance);
+      v = binormalsArray->GetTuple3(tupleIndex);
+      CHECK_DOUBLE_TOLERANCE(v[0], 0.0, tolerance);
+      CHECK_DOUBLE_TOLERANCE(v[1], 0.752577, tolerance);
+      CHECK_DOUBLE_TOLERANCE(v[2], 0.658505, tolerance);
+      v = tangentsArray->GetTuple3(tupleIndex);
+      CHECK_DOUBLE_TOLERANCE(v[0], -0.267407, tolerance);
+      CHECK_DOUBLE_TOLERANCE(v[1], -0.634524, tolerance);
+      CHECK_DOUBLE_TOLERANCE(v[2], 0.725171, tolerance);
+      }
+  }
+
+  // Test with an arc section
+
+  vtkNew<vtkArcSource> arc;
+  double arcCenter[3] = { 40, 50, 60 };
+  double arcNormal[3] = { 0.3, -0.4, 0.9 };
+  vtkMath::Normalize(arcNormal);
+  arc->SetAngle(90);
+  arc->SetCenter(arcCenter);
+  arc->SetPolarVector(5, 15, -3);
+  arc->UseNormalAndAngleOn();
+  arc->SetResolution(200);
+
+  // Make the initial radial direction as preferred initial normal direction.
+  // This will make the binormal direction parallel with the arc's plane normal,
+  // which will remain constant over the entire arc.
+  arc->Update();
+  double arcFirstPoint[3] = { 0,0,0 };
+  arc->GetOutput()->GetPoint(0, arcFirstPoint);
+  double preferredNormalDirection[3] = { arcCenter[0] - arcFirstPoint[0], arcCenter[1] - arcFirstPoint[1], arcCenter[2] - arcFirstPoint[2] };
+  parallelTransportFrame->SetPreferredInitialNormalVector(preferredNormalDirection);
+  
+  parallelTransportFrame->SetInputConnection(arc->GetOutputPort());
+  parallelTransportFrame->Update();
+
+  {
+    vtkPoints* points = parallelTransportFrame->GetOutput()->GetPoints();
+    vtkPointData* pointData = parallelTransportFrame->GetOutput()->GetPointData();
+    vtkDoubleArray* normalsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Normals"));
+    vtkDoubleArray* binormalsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Binormals"));
+    vtkDoubleArray* tangentsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Tangents"));
+    double constantBinormal[3] = { 0.0, 0.0, 0.0 };
+    binormalsArray->GetTypedTuple(0, constantBinormal);
+    for (vtkIdType tupleIndex = 1; tupleIndex < normalsArray->GetNumberOfTuples(); tupleIndex++)
+      {
+      double normal[3] = { 0.0, 0.0, 0.0 };
+      normalsArray->GetTypedTuple(tupleIndex, normal);
+      double binormal[3] = { 0.0, 0.0, 0.0 };
+      binormalsArray->GetTypedTuple(tupleIndex, binormal);
+
+      double pointPosition[3];
+      points->GetPoint(tupleIndex, pointPosition);
+      double radialDirection[3] = { arcCenter[0] - pointPosition[0], arcCenter[1] - pointPosition[1], arcCenter[2] - pointPosition[2] };
+      vtkMath::Normalize(radialDirection);
+
+      if (verbose)
+        {
+        std::cout << "Circle point [" << tupleIndex << "]" << std::endl;
+        std::cout << "  normal: " << normal[0] << ", " << normal[1] << ", " << normal[2] << std::endl;
+        std::cout << "  binormal: " << binormal[0] << ", " << binormal[1] << ", " << binormal[2] << std::endl;
+        std::cout << "  radial: " << radialDirection[0] << ", " << radialDirection[1] << ", " << radialDirection[2] << std::endl;
+        }
+
+      // Use a bit less tight tolerance for the normal (radial) comparison,
+      // because the arc is estimated from straight line segments
+      CHECK_DOUBLE_TOLERANCE(normal[0], radialDirection[0], tolerance * 10.0);
+      CHECK_DOUBLE_TOLERANCE(normal[1], radialDirection[1], tolerance * 10.0);
+      CHECK_DOUBLE_TOLERANCE(normal[2], radialDirection[2], tolerance * 10.0);
+
+      CHECK_DOUBLE_TOLERANCE(binormal[0], constantBinormal[0], tolerance);
+      CHECK_DOUBLE_TOLERANCE(binormal[1], constantBinormal[1], tolerance);
+      CHECK_DOUBLE_TOLERANCE(binormal[2], constantBinormal[2], tolerance);
+      }
+  }
+
+  std::cout << "Test succeeded." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/vtkParallelTransportFrame.cxx
+++ b/vtkParallelTransportFrame.cxx
@@ -1,0 +1,263 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+/*
+  Portions of vtkParallelTransportFrame::ComputeAxisDirections method
+  are covered under the VMTK copyright and BSD license:
+
+    Copyright (c) Luca Antiga, David Steinman. All rights reserved.
+    See https://github.com/vmtk/vmtk/blob/master/LICENSE file for details.
+*/
+
+#include "vtkParallelTransportFrame.h"
+
+#include "vtkDoubleArray.h"
+#include "vtkInformation.h"
+#include "vtkInformationVector.h"
+#include "vtkMath.h"
+#include "vtkNew.h"
+#include "vtkObjectFactory.h"
+#include "vtkPointData.h"
+#include "vtkPolyLine.h"
+
+vtkStandardNewMacro(vtkParallelTransportFrame);
+
+//----------------------------------------------------------------------------
+vtkParallelTransportFrame::vtkParallelTransportFrame()
+{
+  this->SetTangentsArrayName("Tangents");
+  this->SetNormalsArrayName("Normals");
+  this->SetBinormalsArrayName("Binormals");
+}
+
+//----------------------------------------------------------------------------
+vtkParallelTransportFrame::~vtkParallelTransportFrame()
+{
+  this->SetTangentsArrayName(nullptr);
+  this->SetNormalsArrayName(nullptr);
+  this->SetBinormalsArrayName(nullptr);
+}
+
+//----------------------------------------------------------------------------
+void vtkParallelTransportFrame::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  os << indent << "TangentsArrayName: " << (this->TangentsArrayName ? this->TangentsArrayName : "(none)") << "\n";
+  os << indent << "NormalsArrayName: " << (this->NormalsArrayName ? this->NormalsArrayName : "(none)") << "\n";
+  os << indent << "BinormalsArrayName: " << (this->BinormalsArrayName ? this->BinormalsArrayName : "(none)") << "\n";
+
+  os << indent << "Tolerance: " << this->Tolerance << "\n";
+  os << indent << "MinimumDistance: " << this->MinimumDistance << "\n";
+
+  os << indent << "PreferredInitialNormalVector: ("
+    << this->PreferredInitialNormalVector[0] << ", " << this->PreferredInitialNormalVector[1] << ", " << this->PreferredInitialNormalVector[2] << ")\n";
+  os << indent << "PreferredInitialBinormalVector: ("
+    << this->PreferredInitialBinormalVector[0] << ", " << this->PreferredInitialBinormalVector[1] << ", " << this->PreferredInitialBinormalVector[2] << ")\n";
+}
+
+//----------------------------------------------------------------------------
+int vtkParallelTransportFrame::RequestData(
+  vtkInformation* vtkNotUsed(request),
+  vtkInformationVector** inputVector,
+  vtkInformationVector* outputVector)
+{
+  // get the info objects
+  vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+
+  // get the input and ouptut
+  vtkPolyData* input = vtkPolyData::SafeDownCast(inInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkPolyData* output = vtkPolyData::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  if (!this->TangentsArrayName)
+    {
+    vtkErrorMacro(<< "TangentsArrayName is not specified");
+    return 0;
+    }
+  if (!this->NormalsArrayName)
+    {
+    vtkErrorMacro(<< "NormalsArrayName is not specified");
+    return 0;
+    }
+  if (!this->BinormalsArrayName)
+    {
+    vtkErrorMacro(<< "BinormalsArrayName is not specified");
+    return 0;
+    }
+
+  output->DeepCopy(input);
+
+  vtkNew<vtkDoubleArray> tangentsArray;
+  tangentsArray->SetNumberOfComponents(3);
+  tangentsArray->SetName(this->TangentsArrayName);
+
+  vtkNew<vtkDoubleArray> normalsArray;
+  normalsArray->SetNumberOfComponents(3);
+  normalsArray->SetName(this->NormalsArrayName);
+
+  vtkNew<vtkDoubleArray> binormalsArray;
+  binormalsArray->SetNumberOfComponents(3);
+  binormalsArray->SetName(this->BinormalsArrayName);
+
+  vtkIdType numberOfPoints = input->GetNumberOfPoints();
+  tangentsArray->SetNumberOfTuples(numberOfPoints);
+  tangentsArray->Fill(0.0);
+  normalsArray->SetNumberOfTuples(numberOfPoints);
+  normalsArray->Fill(0.0);
+  binormalsArray->SetNumberOfTuples(numberOfPoints);
+  binormalsArray->Fill(0.0);
+
+  int numberOfCells = input->GetNumberOfCells();
+  for (int cellIndex = 0; cellIndex < numberOfCells; cellIndex++)
+    {
+    this->ComputeAxisDirections(input, cellIndex, tangentsArray, normalsArray, binormalsArray);
+    }
+
+  output->GetPointData()->AddArray(tangentsArray);
+  output->GetPointData()->AddArray(normalsArray);
+  output->GetPointData()->AddArray(binormalsArray);
+
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+void vtkParallelTransportFrame::ComputeAxisDirections(vtkPolyData* input, vtkIdType cellIndex, vtkDoubleArray* tangentsArray, vtkDoubleArray* normalsArray, vtkDoubleArray* binormalsArray)
+{
+  vtkPolyLine* polyLine = vtkPolyLine::SafeDownCast(input->GetCell(cellIndex));
+  if (!polyLine)
+    {
+    return;
+    }
+  vtkIdType numberOfPointsInCell = polyLine->GetNumberOfPoints();
+  if (numberOfPointsInCell < 2)
+    {
+    return;
+    }
+
+  double tangent0[3] = { 0.0, 0.0, 0.0 };
+  vtkIdType pointId0 = polyLine->GetPointId(0);
+  double pointPosition0[3];
+  input->GetPoint(pointId0, pointPosition0);
+
+  // Find tangent by direction vector by moving a minimal distance from the initial point
+  for (int pointIndex = 1; pointIndex < numberOfPointsInCell; pointIndex++)
+    {
+    vtkIdType pointId1 = polyLine->GetPointId(pointIndex);
+    double pointPosition1[3];
+    input->GetPoint(pointId1, pointPosition1);
+    tangent0[0] = pointPosition1[0] - pointPosition0[0];
+    tangent0[1] = pointPosition1[1] - pointPosition0[1];
+    tangent0[2] = pointPosition1[2] - pointPosition0[2];
+    if (vtkMath::Norm(tangent0) >= this->MinimumDistance)
+      {
+      break;
+      }
+    }
+  vtkMath::Normalize(tangent0);
+
+  // Compute initial normal and binormal directions from the initial tangent and preferred
+  // normal/binormal directions.
+  double normal0[3] = {0.0, 0.0, 0.0};
+  double binormal0[3] = {0.0, 0.0, 0.0};
+  vtkMath::Cross(tangent0, this->PreferredInitialNormalVector, binormal0);
+  if (vtkMath::Norm(binormal0) > this->Tolerance)
+    {
+    vtkMath::Normalize(binormal0);
+    vtkMath::Cross(binormal0, tangent0, normal0);
+    }
+  else
+    {
+    vtkMath::Cross(this->PreferredInitialBinormalVector, tangent0, normal0);
+    vtkMath::Normalize(normal0);
+    vtkMath::Cross(tangent0, normal0, binormal0);
+    }
+
+  tangentsArray->SetTuple(pointId0, tangent0);
+  normalsArray->SetTuple(pointId0, normal0);
+  binormalsArray->SetTuple(pointId0, binormal0);
+
+  vtkIdType pointId2 = -1;
+  double tangent1[3] = { tangent0[0], tangent0[1], tangent0[2] };
+  double normal1[3] = { normal0[0], normal0[1], normal0[2] };
+  double binormal1[3] = { binormal0[0], binormal0[1], binormal0[2] };
+  for (int i = 1; i < numberOfPointsInCell - 1; i++)
+    {
+    vtkIdType pointId1 = polyLine->GetPointId(i);
+    pointId2 = polyLine->GetPointId(i+1);
+    double pointPosition1[3];
+    double pointPosition2[3];
+    input->GetPoint(pointId1, pointPosition1);
+    input->GetPoint(pointId2, pointPosition2);
+
+    tangent1[0] = pointPosition2[0] - pointPosition1[0];
+    tangent1[1] = pointPosition2[1] - pointPosition1[1];
+    tangent1[2] = pointPosition2[2] - pointPosition1[2];
+
+    vtkMath::Normalize(tangent0);
+    vtkMath::Normalize(tangent1);
+
+    double dot = vtkMath::Dot(tangent0, tangent1);
+    double theta = 0.0;
+   if ((1 - dot) < this->Tolerance)
+      {
+      theta = 0.0;
+      }
+    else
+      {
+      theta = acos(dot);
+      }
+
+    double rotationAxis[3];
+    vtkMath::Cross(tangent0, tangent1, rotationAxis);
+
+    vtkParallelTransportFrame::RotateVector(normal0, normal1, rotationAxis, theta);
+
+    dot = vtkMath::Dot(tangent1, normal1);
+    normal1[0] -= dot * tangent1[0];
+    normal1[1] -= dot * tangent1[1];
+    normal1[2] -= dot * tangent1[2];
+
+    vtkMath::Normalize(normal1);
+    vtkMath::Cross(tangent1, normal1, binormal1);
+
+    tangentsArray->SetTuple(pointId1, tangent1);
+    normalsArray->SetTuple(pointId1, normal1);
+    binormalsArray->SetTuple(pointId1, binormal1);
+
+    // Save current data for next iteration
+    tangent0[0] = tangent1[0];
+    tangent0[1] = tangent1[1];
+    tangent0[2] = tangent1[2];
+    normal0[0] = normal1[0];
+    normal0[1] = normal1[1];
+    normal0[2] = normal1[2];
+    }
+
+  if (pointId2 >= 0)
+    {
+    tangentsArray->SetTuple(pointId2, tangent1);
+    normalsArray->SetTuple(pointId2, normal1);
+    binormalsArray->SetTuple(pointId2, binormal1);
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkParallelTransportFrame::RotateVector(double* inVector, double* outVector, const double* axis, double angle)
+{
+  double UdotN = vtkMath::Dot(inVector, axis);
+  double NcrossU[3];
+  vtkMath::Cross(axis, inVector, NcrossU);
+  for (int comp = 0; comp < 3; comp++)
+    {
+    outVector[comp] = cos(angle) * inVector[comp]
+      + (1 - cos(angle)) * UdotN * axis[comp]
+      + sin(angle) * NcrossU[comp];
+    }
+}

--- a/vtkParallelTransportFrame.h
+++ b/vtkParallelTransportFrame.h
@@ -1,0 +1,119 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+/// \brief Compute orthonormal basis along a curve with minimal torsion.
+/// 
+/// Parallel transport frame provides a smoothly changing orthonormal basis
+/// along a curve. The basic idea is to sweep an initial orthonormal coordinate
+/// frame along the line without being affected by torsion: at each point, the unit
+/// vectors making up the frame are rotated of the exact amount required by curvature,
+///
+/// Vectors of the basis: normal (x), binormal (y), tangent (z).
+/// Tangent vector direction is always the curve's tangent.
+/// Normal vector starts pointing towards a preferred orientation.
+/// Binormal is the cross product of tangent and normal.
+///
+/// Note that the classic Frenet-Serret method can be used to compute othonormal basis along
+/// a curve, too. However, in a Frenet-Serret frame the normal is not defined when the
+/// curvature vanishes and abruptly changes orientation when the direction of concavity of the curve
+/// changes. Therefore, Frenet-Serret frame is not usable for arbitrary curves.
+///
+/// References:
+/// - Parallel transport theory: R. Bishop, "There is more than one way to frame a curve",
+///   American Mathematical Monthly, vol. 82, no. 3, pp. 246–251, 1975
+/// - Parallel transport implementation: Piccinelli M, Veneziani A, Steinman DA, Remuzzi A, Antiga L.
+///   "A framework for geometric analysis of vascular structures: application to cerebral aneurysms.",
+///   IEEE Trans Med Imaging. 2009 Aug;28(8):1141-55. doi: 10.1109/TMI.2009.2021652.
+/// 
+/// The initial implementation was based on VMTK (vtkvmtkCenterlineAttributesFilter) which was optimized
+/// and enhanced with more predictable initial normal vector direction. In the future, support for closed
+/// curves may be added (where constant torsion need to be added or subtracted to make the normal directions
+/// match between the start and end point of the curve).
+
+#ifndef vtkParallelTransportFrame_h
+#define vtkParallelTransportFrame_h
+
+#include "vtkAddon.h"  // For export macro
+#include "vtkPolyDataAlgorithm.h"
+
+class VTK_ADDON_EXPORT vtkParallelTransportFrame : public vtkPolyDataAlgorithm
+{
+public:
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+  vtkTypeMacro(vtkParallelTransportFrame, vtkPolyDataAlgorithm);
+  static vtkParallelTransportFrame* New();
+
+  ///@{
+  /// Get/set the point array name that contains the tangent (z) axis.
+  /// Default value is "Tangents"
+  vtkSetStringMacro(TangentsArrayName);
+  vtkGetStringMacro(TangentsArrayName);
+  ///@} 
+
+  ///@{
+  /// Get/set the point array name that contains the normals (x) axis.
+  /// Default value is "Normals"
+  vtkSetStringMacro(NormalsArrayName);
+  vtkGetStringMacro(NormalsArrayName);
+  ///@} 
+
+  ///@{
+  /// Get/set the point array name that contains the binormal (y) axis.
+  /// Default value is "Binormals"
+  vtkSetStringMacro(BinormalsArrayName);
+  vtkGetStringMacro(BinormalsArrayName);
+  ///@} 
+
+  /// Define the preferred direction of the normal vector at the first point of the curve.
+  /// It is just "preferred" because the direction has to be orhogonal to the tangent,
+  /// so in general the normal vector cannot point into exactly to a required direction.
+  /// By default it is (1, 0, 0).
+  /// \sa PreferredInitialBinormalVector
+  vtkSetVectorMacro(PreferredInitialNormalVector, double, 3);
+  vtkGetVectorMacro(PreferredInitialNormalVector, double, 3);
+  ///@}
+
+  /// Define the preferred direction of the binormal vector at the first point.
+  /// It is used only if the curve's tangent at the first point is parallel to the
+  /// preferred initial normal vector.
+  /// By default it is (0, 1, 0).
+  /// \sa PreferredInitialNormalVector
+  vtkSetVectorMacro(PreferredInitialBinormalVector, double, 3);
+  vtkGetVectorMacro(PreferredInitialBinormalVector, double, 3);
+  ///@}
+
+protected:
+  vtkParallelTransportFrame();
+  ~vtkParallelTransportFrame() override;
+
+  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+
+  void ComputeAxisDirections(vtkPolyData* input, vtkIdType cellIndex, vtkDoubleArray* tangentsArray, vtkDoubleArray* normalsArray, vtkDoubleArray* binormalsArray);
+
+  /// Rotate a vector around an axis
+  static void RotateVector(double* inVector, double* outVector, const double* axis, double angle);
+
+private:
+  vtkParallelTransportFrame(const vtkParallelTransportFrame&) = delete;
+  void operator=(const vtkParallelTransportFrame&) = delete;
+
+  char* TangentsArrayName = nullptr;
+  char* NormalsArrayName = nullptr;
+  char* BinormalsArrayName = nullptr;
+
+  /// Tolerance value used for checking that a value is non-zero.
+  double Tolerance = 1e-6;
+  /// Minimum distance for comuting initial tangent direction
+  double MinimumDistance = 1e-3;
+  
+  double PreferredInitialNormalVector[3] = { 1.0, 0.0, 0.0 };
+  double PreferredInitialBinormalVector[3] = { 0.0, 0.0, 0.0 };
+};
+
+#endif // vtkParallelTransportFrame_h


### PR DESCRIPTION
The modified Frenet-Serret frame based computation available in SplineDrivenImageSlicer was not robust.
It had random initial normal direction and it was not robust when points were too close to each other.
See https://github.com/Slicer/Slicer/issues/5559 for details.

This new reference frame computation based on parallel transport is robust and predictable.
