### PR TITLE
BUG: Fix fabs not declared in vtkAddonTestingUtilities

### DIFF
--- a/vtkAddonTestingUtilities.cxx
+++ b/vtkAddonTestingUtilities.cxx
@@ -22,6 +22,7 @@
 
 // STD includes
 #include <iostream>
+#include <cmath> // for fabs
 
 namespace vtkAddonTestingUtilities
 {


### PR DESCRIPTION
Adding `<cmath>` header