### PR TITLE
BUG: fix VTK 8.2.0 bug for C++17 "clamp" function in vtkMath.h

### DIFF
--- a/Testing/vtkAddonMathUtilitiesTest1.cxx
+++ b/Testing/vtkAddonMathUtilitiesTest1.cxx
@@ -17,6 +17,7 @@
 
 // std includes
 #include <sstream>
+#include <algorithm> // VTK 8.2.0 has bug for C++17 "clamp" function (algorithm must be included before vtMath.h)
 
 // vtkAddon includes
 #include "vtkAddonMathUtilities.h"

--- a/vtkAddonMathUtilities.cxx
+++ b/vtkAddonMathUtilities.cxx
@@ -18,6 +18,7 @@
 #include <vector>
 #include <cstdlib>
 #include <cmath>
+#include <algorithm> // VTK 8.2.0 has bug for C++17 "clamp" function (algorithm must be included before vtMath.h)
 
 // VTK includes
 #include "vtk_eigen.h"

--- a/vtkOrientedBSplineTransform.cxx
+++ b/vtkOrientedBSplineTransform.cxx
@@ -7,6 +7,8 @@
 
 =========================================================================auto=*/
 
+#include <algorithm> // VTK 8.2.0 has bug for C++17 "clamp" function (algorithm must be included before vtMath.h)
+
 #include "vtkOrientedBSplineTransform.h"
 
 #include "vtkImageData.h"

--- a/vtkOrientedGridTransform.cxx
+++ b/vtkOrientedGridTransform.cxx
@@ -7,6 +7,8 @@
 
 =========================================================================auto=*/
 
+#include <algorithm> // VTK 8.2.0 has bug for C++17 "clamp" function (algorithm must be included before vtMath.h)
+
 #include "vtkOrientedGridTransform.h"
 
 #include "vtkMath.h"

--- a/vtkParallelTransportFrame.cxx
+++ b/vtkParallelTransportFrame.cxx
@@ -15,6 +15,8 @@
     See https://github.com/vmtk/vmtk/blob/master/LICENSE file for details.
 */
 
+#include <algorithm> // VTK 8.2.0 has bug for C++17 "clamp" function (algorithm must be included before vtMath.h)
+
 #include "vtkParallelTransportFrame.h"
 
 #include "vtkDoubleArray.h"


### PR DESCRIPTION
This is harmless fix aimed to fix VTK 8.2.0 bug.

In VTK 8.2.0's [vtkMath.h](https://gitlab.kitware.com/vtk/vtk/-/blob/v8.2.0/Common/Core/vtkInformationObjectBaseKey.cxx) templated functions [std::clamp](https://en.cppreference.com/w/cpp/algorithm/clamp) is used for C++17 and higher. But to use `std::clamp` algorithm must be included `#include <algorithm>`. This is omitted in VTK 8.2.0 but fixed in [VTK 9.0.1](https://gitlab.kitware.com/vtk/vtk/-/blob/v9.0.0/Common/Core/vtkMath.h#L49).

My use case is to compile SlicerCAT with C++17 enabled and it seems that with these changes it works.