### PR TITLE
Fix issues related to project install in conan context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,15 +284,19 @@ install(
   DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKE_DIR}
   )
 
+install(TARGETS ${lib_name} EXPORT vtkAddonTargets)
+install(EXPORT vtkAddonTargets
+    DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKE_DIR}
+)
+
 # Install vtkAddon CMake files
 install(
   FILES
-  ${CMAKE_SOURCE_DIR}/CMake/vtkAddonFunctionAddExecutable.cmake
-  ${CMAKE_SOURCE_DIR}/CMake/vtkAddonFunctionAddExecutable.cmake
-  ${CMAKE_SOURCE_DIR}/CMake/vtkMacroKitPythonWrap.cmake
-  ${CMAKE_SOURCE_DIR}/CMake/vtkWrapHierarchy.cmake
-  ${CMAKE_SOURCE_DIR}/CMake/vtkWrapperInit.data.in
-  ${CMAKE_SOURCE_DIR}/CMake/vtkWrapPython.cmake
-  ${CMAKE_SOURCE_DIR}/CMake/WindowsApplicationUseUtf8.manifest
+  ${CMAKE_CURRENT_SOURCE_DIR}/CMake/vtkAddonFunctionAddExecutable.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/CMake/vtkMacroKitPythonWrap.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/CMake/vtkWrapHierarchy.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/CMake/vtkWrapperInit.data.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/CMake/vtkWrapPython.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/CMake/WindowsApplicationUseUtf8.manifest
   DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKE_DIR} COMPONENT Development
   )

--- a/vtkAddonInstallConfig.cmake.in
+++ b/vtkAddonInstallConfig.cmake.in
@@ -1,3 +1,5 @@
+include("@CMAKE_INSTALL_PREFIX@/@vtkAddon_INSTALL_CMAKE_DIR@/vtkAddonTargets.cmake")
+
 set(vtkAddon_CMAKE_DIR "@CMAKE_INSTALL_PREFIX@/@vtkAddon_INSTALL_CMAKE_DIR@")
 set(vtkAddon_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/@vtkAddon_INSTALL_INCLUDE_DIR@")
 set(vtkAddon_LIB_DIR "@CMAKE_INSTALL_PREFIX@/@vtkAddon_INSTALL_LIB_DIR@")


### PR DESCRIPTION
* Prevent use of CMAKE_SOURCE_DIR that can be different of project
source dir when project root CMakeLists.txt is called from an upper
layer

* Add export of the target file that is necessary to make use of CMake
targets in a client project