### PR TITLE
COMP: Add guard for deprecated header vtkOpenGL.h

### DIFF
--- a/vtkOpenGLShaderComputation.cxx
+++ b/vtkOpenGLShaderComputation.cxx
@@ -19,7 +19,10 @@
 #include "vtkDataArray.h"
 #include "vtkImageData.h"
 #include "vtkObjectFactory.h"
-#include "vtkOpenGL.h"
+// vtkOpenGL.h is deprecated for vtk < 9.1. Use vtk_glew.h instead.
+#if !(VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 1)
+  #include "vtkOpenGL.h"
+#endif
 #include "vtkOpenGLError.h"
 #include "vtkOpenGLRenderWindow.h"
 #include "vtkPointData.h"

--- a/vtkOpenGLTextureImage.cxx
+++ b/vtkOpenGLTextureImage.cxx
@@ -26,7 +26,10 @@
 #include "vtkPolyDataMapper.h"
 #include "vtkProperty.h"
 
-#include "vtkOpenGL.h"
+// vtkOpenGL.h is deprecated for vtk < 9.1. Use vtk_glew.h instead.
+#if !(VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 1)
+  #include "vtkOpenGL.h"
+#endif
 #include <math.h>
 
 //----------------------------------------------------------------------------

--- a/vtkOpenGLTextureImage.h
+++ b/vtkOpenGLTextureImage.h
@@ -27,7 +27,11 @@
 #include "vtk_glew.h"
 
 #include "vtkOpenGLShaderComputation.h"
-#include "vtkOpenGL.h"
+#include "vtkVersionMacros.h"
+// vtkOpenGL.h is deprecated for vtk < 9.1. Use vtk_glew.h instead.
+#if !(VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 1)
+  #include "vtkOpenGL.h"
+#endif
 
 #include "vtkImageData.h"
 


### PR DESCRIPTION
vtkOpenGL.h has been deprecated and should not be
used for vtk >= 9.1.