### PR TITLE
remove unnecessary link against VTK_PYTHON_LIBRARIES

### DIFF
--- a/CMake/vtkMacroKitPythonWrap.cmake
+++ b/CMake/vtkMacroKitPythonWrap.cmake
@@ -160,8 +160,10 @@ macro(vtkMacroKitPythonWrap)
 
   if(VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
 
+    if (${VTK_VERSION} VERSION_LESS "8.90")
     # Tell vtkWrapPython.cmake to set VTK_PYTHON_LIBRARIES for us.
     set(VTK_WRAP_PYTHON_FIND_LIBS 1)
+    endif()
     include(vtkWrapPython)
 
     set(TMP_WRAP_FILES ${MY_KIT_SRCS} ${MY_KIT_WRAP_HEADERS})
@@ -344,7 +346,6 @@ macro(vtkMacroKitPythonWrap)
     target_link_libraries(${MY_KIT_NAME}Python
       PRIVATE
         ${MY_KIT_NAME}
-        ${VTK_PYTHON_LIBRARIES}
         VTK::WrappingPythonCore
         VTK::Python
         )


### PR DESCRIPTION
As I detail in this PR on the repo to build VMTK for conda-forge on macOS (https://github.com/conda-forge/vmtk-feedstock/pull/4), the cmake macro `vtkMacroKitPythonWrap` (in a .cmake of the same name) incorrectly links against the python library:
```cmake
target_link_libraries(${MY_KIT_NAME}Python
      PRIVATE
        ${MY_KIT_NAME}
        ${VTK_PYTHON_LIBRARIES} #error
        VTK::WrappingPythonCore
        VTK::Python
        )
```
Any link that is needed should be picked up through the link against VTK::Python (assuming its INTERFACE_LINK_LIBRARIES property is correctly set - VTK is usually quite good about that)

In this patch I correct this oversight which causes the resulting module (on macOS at least) to be non-functional when imported into a python interpreter that is NOT linked against libpython3.xm.dylib