### PR TITLE
COMP: Support VTK > 9.1 using vtk_glew.h instead of deprecated vtkOpenGL.h

### DIFF
--- a/vtkOpenGLShaderComputation.cxx
+++ b/vtkOpenGLShaderComputation.cxx
@@ -19,7 +19,6 @@
 #include "vtkDataArray.h"
 #include "vtkImageData.h"
 #include "vtkObjectFactory.h"
-#include "vtkOpenGL.h"
 #include "vtkOpenGLError.h"
 #include "vtkOpenGLRenderWindow.h"
 #include "vtkPointData.h"

--- a/vtkOpenGLShaderComputation.h
+++ b/vtkOpenGLShaderComputation.h
@@ -21,7 +21,6 @@
 #define __vtkOpenGLShaderComputation_h
 
 // VTK includes
-//#include "vtk_glew.h"
 #include "vtkAddon.h"
 #include "vtkImageData.h"
 #include "vtkRenderWindow.h"

--- a/vtkOpenGLTextureImage.cxx
+++ b/vtkOpenGLTextureImage.cxx
@@ -26,7 +26,6 @@
 #include "vtkPolyDataMapper.h"
 #include "vtkProperty.h"
 
-#include "vtkOpenGL.h"
 #include <math.h>
 
 //----------------------------------------------------------------------------

--- a/vtkOpenGLTextureImage.h
+++ b/vtkOpenGLTextureImage.h
@@ -27,7 +27,6 @@
 #include "vtk_glew.h"
 
 #include "vtkOpenGLShaderComputation.h"
-#include "vtkOpenGL.h"
 
 #include "vtkImageData.h"
 


### PR DESCRIPTION
For reference, the use of "vtkOpenGL.h" has been deprecated since kitware/VTK@3aa735f98 (Fix ios compile issue due to opengl include) indicating the following:

```
  VTK uses glew now and so opengl should be included through glew.
```