### PR TITLE
COMP: vtkMacroKitPythonWrap: Remove obsolete use of PYTHON_INCLUDE_PATH

### DIFF
--- a/CMake/vtkMacroKitPythonWrap.cmake
+++ b/CMake/vtkMacroKitPythonWrap.cmake
@@ -228,8 +228,6 @@ macro(vtkMacroKitPythonWrap)
 
     VTK_WRAP_PYTHON3(${MY_KIT_NAME}Python KitPython_SRCS "${TMP_WRAP_FILES}")
 
-    include_directories("${PYTHON_INCLUDE_PATH}")
-
     if(${VTK_VERSION} VERSION_LESS "8.90")
 
     # Create a python module that can be loaded dynamically.  It links to


### PR DESCRIPTION
Use of `PYTHON_INCLUDE_PATH` originally added to `CMake/KitCommonPythonWrapBlock.cmake` in kitware/VTK@0f898bff8 (VTK v5.8.0). Then, after Kitware/VTK@c13ff7ba7 (VTK v6.0.0), the file `CMake/KitCommonPythonWrapBlock.cmake` was completely removed and there are no explicit use of `PYTHON_INCLUDE_PATH` in the VTK code base.

Since the use of `PYTHON_INCLUDE_PATH` in Slicer was originally introduced in `vtkMacroKitPythonWrap` through Slicer/Slicer@59c8640c6 (COMP: Factor out VTK specific python wrapping code into vtkMacroKitPythonWrap) which was associated with VTK v5.10.0, this commit completely removes its use since only VTK >= 8.2.0 is now supported following a64d854cd (COMP: Update vtkMacroKitPythonWrap removing support for VTK < 8.2)