### PR TITLE
BUG: Fix Python module names

### DIFF
--- a/CMake/vtkWrapHierarchy.cmake
+++ b/CMake/vtkWrapHierarchy.cmake
@@ -98,7 +98,7 @@ $<$<BOOL:$<TARGET_PROPERTY:${module_name},INCLUDE_DIRECTORIES>>:
 
       # add the info to the init file
       set(VTK_WRAPPER_INIT_DATA
-        "${VTK_WRAPPER_INIT_DATA}${TMP_INPUT};${_name}")
+        "${VTK_WRAPPER_INIT_DATA}${TMP_INPUT};${_name}Python")
 
       set(VTK_WRAPPER_INIT_DATA "${VTK_WRAPPER_INIT_DATA}\n")
 


### PR DESCRIPTION
The class module names (`cls.__module__`) for classes wrapped with this wrapping were incorrect. For example, `vtkAddonMathUtilities.__module__` returns "vtkAddon", while the actual python package is "vtkAddonPython".

This updates module names to have the Python suffix.

It was chosen to update the module names to have the Python suffix instead of removing the Python suffix on the module itself for backwards compatibility reasons.

Note: The same problem happens for all the MRML nodes in 3D Slicer.