### PR TITLE
ENH:  Get the coordinates of a point along a line by offset.

### DIFF
--- a/vtkAddonMathUtilities.cxx
+++ b/vtkAddonMathUtilities.cxx
@@ -388,3 +388,14 @@ bool vtkAddonMathUtilities::FitPlaneToPoints(vtkPoints* points, vtkMatrix4x4* tr
 
   return true;
 }
+
+//---------------------------------------------------------------------------
+void vtkAddonMathUtilities::GetPointAlongLine(double result[3], double p1[3], double p2[3], const double offset)
+{
+  double directionVector[3] = { p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2] };
+  vtkMath::Normalize(directionVector);
+  result[0] = p2[0] + (offset * directionVector[0]);
+  result[1] = p2[1] + (offset * directionVector[1]);
+  result[2] = p2[2] + (offset * directionVector[2]);
+}
+

--- a/vtkAddonMathUtilities.h
+++ b/vtkAddonMathUtilities.h
@@ -85,6 +85,9 @@ public:
 
   /// Compute transform that best transforms the XY plane to the best fit plane
   static bool FitPlaneToPoints(vtkPoints* points, vtkMatrix4x4* transformToBestFitPlane);
+  
+  /// Get the coordinates of a point along a line at an offset from p2.
+  static void GetPointAlongLine(double result[3], double p1[3], double p2[3], const double offset);
 
 protected:
   vtkAddonMathUtilities();


### PR DESCRIPTION
Hi @lassoan ,

Following this [discussion](https://discourse.slicer.org/t/rfc-should-this-method-be-generally-available/28332), I have resolved to request addition of 'GetPointAlongLine()' function as in this patch. The name and parameters are intuitive, and callers have minimal variables to declare.

Thanks for having considered.
