### PR TITLE
COMP: Fix deprecation warnings by explicitly calling vtkStdString::c_str()

### DIFF
--- a/Testing/vtkPersonInformationTest1.cxx
+++ b/Testing/vtkPersonInformationTest1.cxx
@@ -60,8 +60,8 @@ int vtkPersonInformationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   vtkNew<vtkStringArray> keys;
   userInformation->GetKeys(keys.GetPointer());
   CHECK_INT(keys->GetNumberOfValues(), 6);
-  CHECK_STRING(keys->GetValue(0), "Email");
-  CHECK_STRING(keys->GetValue(5), "ProcedureRole");
+  CHECK_STRING(keys->GetValue(0).c_str(), "Email");
+  CHECK_STRING(keys->GetValue(5).c_str(), "ProcedureRole");
 
   // Test key delete
   CHECK_BOOL(userInformation->SetName(""), true);
@@ -73,8 +73,8 @@ int vtkPersonInformationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   CHECK_STD_STRING(userInformation->GetAsString(), outputAfterNameDelete);
   userInformation->GetKeys(keys.GetPointer());
   CHECK_INT(keys->GetNumberOfValues(), 5);
-  CHECK_STRING(keys->GetValue(0), "Email");
-  CHECK_STRING(keys->GetValue(4), "ProcedureRole");
+  CHECK_STRING(keys->GetValue(0).c_str(), "Email");
+  CHECK_STRING(keys->GetValue(4).c_str(), "ProcedureRole");
 
   // Test all key delete
   CHECK_BOOL(userInformation->SetLogin(""), true);


### PR DESCRIPTION
This commit fixes warnings like the following:

```
/path/to/vtkAddon/Testing/vtkPersonInformationTest1.cxx: In function ‘int vtkPersonInformationTest1(int, char**)’: /path/to/vtkAddon/vtkAddonTestingMacros.h:159:101: warning: ‘vtkStdString::operator const char*()’ is deprecated: Call `.c_str()` explicitly [-Wdeprecated-declarations]
  159 |   if (!vtkAddonTestingUtilities::CheckString(__LINE__,#actual " != " #expected, (actual), (expected))) \
      |                                                                                                     ^
```