### PR TITLE
Fix dependent scope gcc build error in vtkImageLabelDilate3D

### DIFF
--- a/vtkImageLabelDilate3D.cxx
+++ b/vtkImageLabelDilate3D.cxx
@@ -78,11 +78,11 @@ T vtkComputeModeOfArray(const std::vector<T>& values) {
   // A map to store the count of each value
   std::map<T, int> valueCount;
   T maxValue = 0; // the most frequent value found so far
-  int maxCount = 0; // how many of this value are found so far
+  std::size_t maxCount = 0; // how many of this value are found so far
   typename std::vector<T>::size_type countForMajority = typename std::vector<T>::size_type(values.size() / 2); // more than this count means majority
   for (T value : values)
     {
-    int count = ++valueCount[value];
+    std::size_t count = ++valueCount[value];
     if (count > maxCount)
       {
       maxValue = value;

--- a/vtkImageLabelDilate3D.cxx
+++ b/vtkImageLabelDilate3D.cxx
@@ -73,13 +73,13 @@ namespace
 
 //------------------------------------------------------------------------------
 // Compute the most frequently occurring number in the vector
-template <class T>
+template <typename T>
 T vtkComputeModeOfArray(const std::vector<T>& values) {
   // A map to store the count of each value
   std::map<T, int> valueCount;
   T maxValue = 0; // the most frequent value found so far
   int maxCount = 0; // how many of this value are found so far
-  std::vector<T>::size_type countForMajority = std::vector<T>::size_type(values.size()/2); // more than this count means majority
+  typename std::vector<T>::size_type countForMajority = typename std::vector<T>::size_type(values.size() / 2); // more than this count means majority
   for (T value : values)
     {
     int count = ++valueCount[value];
@@ -102,7 +102,7 @@ T vtkComputeModeOfArray(const std::vector<T>& values) {
 //------------------------------------------------------------------------------
 // This method contains the second switch statement that calls the correct
 // templated function for the mask types.
-template <class T>
+template <typename T>
 void vtkImageLabelDilate3DExecute(vtkImageLabelDilate3D* self, vtkImageData* inData, T* inPtr,
   vtkImageData* outData, T* outPtr, int outExt[6], int id, vtkDataArray* inArray)
 {


### PR DESCRIPTION
Follow-up of https://github.com/Slicer/vtkAddon/commit/8bdd3d7bf0b81a947c5ed82754387b76c2bfd3f5 introduced through:
* https://github.com/Slicer/vtkAddon/pull/41

It also fixes the following warning:

```

/path/to/vtkAddon/vtkImageLabelDilate3D.cxx:90:17: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<double>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
   90 |       if (count > countForMajority)
      |           ~~~~~~^~~~~~~~~~~~~~~~~~
```