### PR TITLE
COMP: Update vtkImageLabelDilate3D adding includes for used STL containers

### DIFF
--- a/vtkImageLabelDilate3D.cxx
+++ b/vtkImageLabelDilate3D.cxx
@@ -12,6 +12,9 @@
 #include "vtkPointData.h"
 #include "vtkStreamingDemandDrivenPipeline.h"
 
+#include <map>
+#include <vector>
+
 vtkStandardNewMacro(vtkImageLabelDilate3D);
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This addresses build error on system where such headers are not indirectly included.