### PR TITLE
COMP: Fix unused parameter warnings in `vtkParallelTransportTest1.cxx`

### DIFF
--- a/Testing/vtkParallelTransportTest1.cxx
+++ b/Testing/vtkParallelTransportTest1.cxx
@@ -35,7 +35,6 @@ int vtkParallelTransportTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 
   // Test computation with a straight line input (zero curvature)
 
-  double lineDirection[3] = { 0.0, 0.0, 1.0 };
   vtkNew<vtkLineSource> line;
   line->SetPoint1(10,20,30);
   line->SetPoint1(30,70,-80);
@@ -106,6 +105,8 @@ int vtkParallelTransportTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
       normalsArray->GetTypedTuple(tupleIndex, normal);
       double binormal[3] = { 0.0, 0.0, 0.0 };
       binormalsArray->GetTypedTuple(tupleIndex, binormal);
+      double tangents[3] = { 0.0, 0.0, 0.0 };
+      tangentsArray->GetTypedTuple(tupleIndex, tangents);
 
       double pointPosition[3];
       points->GetPoint(tupleIndex, pointPosition);
@@ -117,6 +118,7 @@ int vtkParallelTransportTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
         std::cout << "Circle point [" << tupleIndex << "]" << std::endl;
         std::cout << "  normal: " << normal[0] << ", " << normal[1] << ", " << normal[2] << std::endl;
         std::cout << "  binormal: " << binormal[0] << ", " << binormal[1] << ", " << binormal[2] << std::endl;
+        std::cout << "  tangents: " << tangents[0] << ", " << tangents[1] << ", " << tangents[2] << std::endl;
         std::cout << "  radial: " << radialDirection[0] << ", " << radialDirection[1] << ", " << radialDirection[2] << std::endl;
         }
 


### PR DESCRIPTION
Fix unused parameter warnings in `vtkParallelTransportTest1.cxx`:
- Remove the unused `lineDirection` variable.
- Make use of the `tangentsArray` variable by querying its contents using the index and print them.

Fixes:
```
/usr/src/Slicer-build/vtkAddon/Testing/vtkParallelTransportTest1.cxx:
 In function ‘int vtkParallelTransportTest1(int, char**)’:
/usr/src/Slicer-build/vtkAddon/Testing/vtkParallelTransportTest1.cxx:100:21:
 warning: unused variable ‘tangentsArray’ [-Wunused-variable]
     vtkDoubleArray* tangentsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Tangents"));
                     ^~~~~~~~~~~~~
/usr/src/Slicer-build/vtkAddon/Testing/vtkParallelTransportTest1.cxx:38:10:
 warning: unused variable ‘lineDirection’ [-Wunused-variable]
   double lineDirection[3] = { 0.0, 0.0, 1.0 };
          ^~~~~~~~~~~~~
```

https://github.com/Slicer/Slicer/actions/runs/6950843491/job/18911721210#step:4:2749