### PR TITLE
FIX: Replace WIN32 with _WIN32 to fix build with Ninja

### DIFF
--- a/vtkAddonExport.h
+++ b/vtkAddonExport.h
@@ -25,7 +25,7 @@
 
 #include <vtkAddonConfigure.h>
 
-#if defined(WIN32) && !defined(VTKADDON_STATIC)
+#if defined(_WIN32) && !defined(VTKADDON_STATIC)
 #if defined(vtkAddon_EXPORTS)
 #define VTK_ADDON_EXPORT __declspec( dllexport )
 #else


### PR DESCRIPTION
`/DWIN32` is only present in `CMAKE_C[XX]_FLAGS` by default when building with MSBuild. To fix this we should rely on the standard [`_WIN32`  macro defined by MSVC](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170). This enable vtkAddon to be built using the Ninja generator.