### PR TITLE
ENH: Add classes for supporting additional clipping functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,12 +94,18 @@ set(vtkAddon_SRCS
   vtkAddonTestingUtilities.cxx
   vtkAddonTestingUtilities.h
   vtkAddonTestingUtilities.txx
+  vtkCapPolyData.cxx
+  vtkCapPolyData.h
   vtkCurveGenerator.cxx
   vtkCurveGenerator.h
   vtkErrorSink.cxx
   vtkErrorSink.h
   vtkImageLabelDilate3D.cxx
   vtkImageLabelDilate3D.h
+  vtkImageMathematicsAddon.cxx
+  vtkImageMathematicsAddon.h
+  vtkImplicitInvertableBoolean.cxx
+  vtkImplicitInvertableBoolean.h
   vtkLinearSpline.cxx
   vtkLinearSpline.h
   vtkLoggingMacros.h

--- a/vtkCapPolyData.cxx
+++ b/vtkCapPolyData.cxx
@@ -1,0 +1,323 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// vtkAddon includes
+#include "vtkCapPolyData.h"
+
+// VTK includes
+#include <vtkCellArray.h>
+#include <vtkCellData.h>
+#include <vtkClipPolyData.h>
+#include <vtkCutter.h>
+#include <vtkContourTriangulator.h>
+#include <vtkFloatArray.h>
+#include <vtkGeneralTransform.h>
+#include <vtkImplicitBoolean.h>
+#include <vtkImplicitFunctionCollection.h>
+#include <vtkInformationVector.h>
+#include <vtkInformation.h>
+#include <vtkObjectFactory.h>
+#include <vtkPlaneCollection.h>
+#include <vtkPlanes.h>
+#include <vtkPointData.h>
+#include <vtkPolygon.h>
+#include <vtkReverseSense.h>
+
+vtkStandardNewMacro(vtkCapPolyData);
+
+//----------------------------------------------------------------------------
+vtkCapPolyData::vtkCapPolyData() = default;
+
+//----------------------------------------------------------------------------
+vtkCapPolyData::~vtkCapPolyData() = default;
+
+//----------------------------------------------------------------------------
+void vtkCapPolyData::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+  if (this->ClipFunction)
+  {
+    os << indent << "Clip Function: " << this->ClipFunction << "\n";
+  }
+  else
+  {
+    os << indent << "Clip Function: (none)\n";
+  }
+  os << indent << "Generate Outline: " << (this->GenerateOutline ? "On" : "Off") << "\n";
+  os << indent << "Generate Cell Type Scalars: " << (this->GenerateCellTypeScalars ? "On" : "Off") << "\n";
+}
+
+//----------------------------------------------------------------------------
+void vtkCapPolyData::GetPlanes(vtkImplicitFunction* function, vtkPlaneCollection* planes, vtkAbstractTransform* parentTransform/*=nullptr*/)
+{
+  if (!function || !planes)
+  {
+    return;
+  }
+
+  vtkSmartPointer<vtkAbstractTransform> transform = nullptr;
+  vtkAbstractTransform* functionTransform = function->GetTransform();
+  if (functionTransform && parentTransform)
+  {
+    vtkSmartPointer<vtkGeneralTransform> generalTransform = vtkSmartPointer<vtkGeneralTransform>::New();
+    generalTransform->Concatenate(parentTransform);
+    generalTransform->Concatenate(functionTransform);
+    transform = generalTransform;
+  }
+  else if (parentTransform)
+  {
+    transform = parentTransform;
+  }
+  else if (functionTransform)
+  {
+    transform = functionTransform;
+  }
+
+  vtkImplicitBoolean* booleanFunction = vtkImplicitBoolean::SafeDownCast(function);
+  if (booleanFunction)
+  {
+    vtkImplicitFunctionCollection* functions = booleanFunction->GetFunction();
+    for (int i = 0; i < functions->GetNumberOfItems(); ++i)
+    {
+      vtkImplicitFunction* function = vtkImplicitFunction::SafeDownCast(functions->GetItemAsObject(i));
+      vtkCapPolyData::GetPlanes(function, planes, transform);
+    }
+    return;
+  }
+
+  vtkPlanes* planesFunction = vtkPlanes::SafeDownCast(function);
+  if (planesFunction)
+  {
+    for (int i = 0; i < planesFunction->GetNumberOfPlanes(); ++i)
+    {
+      vtkCapPolyData::GetPlanes(planesFunction->GetPlane(i), planes, transform);
+    }
+    return;
+  }
+
+  vtkPlane* plane = vtkPlane::SafeDownCast(function);
+  if (plane)
+  {
+    double planeOrigin[3] = { 0.0, 0.0, 0.0 };
+    plane->GetOrigin(planeOrigin);
+    double planeNormal[3] = { 0.0, 0.0, 0.0 };
+    plane->GetNormal(planeNormal);
+    if (transform)
+    {
+      // vtkCutter with vtkPlane doesn't take transform into account.
+      // Need to apply the transform to the plane manually.
+      vtkAbstractTransform* inverseTransform = transform->GetInverse();
+      inverseTransform->TransformPoint(planeOrigin, planeOrigin);
+      inverseTransform->TransformNormalAtPoint(planeOrigin, planeNormal, planeNormal);
+    }
+
+    vtkNew<vtkPlane> newPlane;
+    newPlane->SetNormal(planeNormal);
+    newPlane->SetOrigin(planeOrigin);
+    planes->AddItem(newPlane);
+  }
+}
+
+
+//----------------------------------------------------------------------------
+void vtkCapPolyData::CreateEndCap(vtkPlaneCollection* planes, vtkPolyData* originalPolyData, vtkImplicitFunction* cutFunction, vtkPolyData* outputEndCap)
+{
+  vtkNew<vtkAppendPolyData> appendFilter;
+  for (int i = 0; i < planes->GetNumberOfItems(); ++i)
+  {
+    vtkPlane* plane = planes->GetItem(i);
+
+    vtkNew<vtkCutter> cutter;
+    cutter->SetCutFunction(plane);
+    cutter->SetInputData(originalPolyData);
+
+    vtkNew<vtkContourTriangulator> contourTriangulator;
+    contourTriangulator->SetInputConnection(cutter->GetOutputPort());
+    contourTriangulator->Update();
+
+    vtkNew<vtkPolyData> endCapPolyData;
+
+    if (this->GenerateOutline)
+    {
+      vtkNew<vtkAppendPolyData> append;
+      append->AddInputData(contourTriangulator->GetOutput());
+      append->AddInputData(cutter->GetOutput());
+      append->SetOutput(endCapPolyData);
+      append->Update();
+    }
+    else
+    {
+      endCapPolyData->ShallowCopy(contourTriangulator->GetOutput());
+    }
+
+    // Create a seam along the intersection of each plane with the triangulated contour.
+    // This allows the contour to be split correctly later.
+    for (int j = 0; j < planes->GetNumberOfItems(); ++j)
+    {
+      if (i == j)
+      {
+        continue;
+      }
+      vtkPlane* plane2 = planes->GetItem(j);
+      vtkNew<vtkClipPolyData> clipper;
+      clipper->SetInputData(endCapPolyData);
+      clipper->SetClipFunction(plane2);
+      clipper->SetValue(0.0);
+      clipper->GenerateClippedOutputOn();
+      vtkNew<vtkAppendPolyData> appendCut;
+      appendCut->AddInputConnection(clipper->GetOutputPort());
+      appendCut->AddInputConnection(clipper->GetClippedOutputPort());
+      appendCut->Update();
+      endCapPolyData->ShallowCopy(appendCut->GetOutput());
+    }
+
+    // Remove all triangles that do not lie at 0.0.
+    double epsilon = 1e-4;
+    vtkNew<vtkClipPolyData> clipper;
+    clipper->SetInputData(endCapPolyData);
+    clipper->SetClipFunction(cutFunction);
+    clipper->InsideOutOff();
+    clipper->SetValue(-epsilon);
+    vtkNew<vtkClipPolyData> clipper2;
+    clipper2->SetInputConnection(clipper->GetOutputPort());
+    clipper2->SetClipFunction(cutFunction);
+    clipper2->InsideOutOn();
+    clipper2->SetValue(epsilon);
+    clipper2->Update();
+    endCapPolyData->ShallowCopy(clipper2->GetOutput());
+
+    double planeNormal[3] = { 0.0 };
+    plane->GetNormal(planeNormal);
+
+    vtkCellArray* endCapPolys = endCapPolyData->GetPolys();
+    if (endCapPolys && endCapPolyData->GetNumberOfPolys() > 0)
+    {
+      vtkNew<vtkIdList> polyPointIds;
+      endCapPolys->GetCell(0, polyPointIds);
+      double polyNormal[3] = { 0.0 };
+
+      // The normal of the triangles generated by vtkContourTriangulator are based on the clockwise/counter-clockwise direction of the largest contour.
+      // This normal will not always line up with the desired normal as defined by the plane, so if the normal generated by vtkContourTriangulator faces
+      // the wrong  direction, then we need to flip the normals of the polys so that it matches the expected normal.
+      vtkPolygon::ComputeNormal(endCapPolyData->GetPoints(), polyPointIds->GetNumberOfIds(), polyPointIds->GetPointer(0), polyNormal);
+      if (vtkMath::Dot(polyNormal, planeNormal) < 0.0)
+      {
+        vtkNew<vtkReverseSense> reverseSense;
+        reverseSense->SetInputData(endCapPolyData);
+        reverseSense->ReverseCellsOn();
+        reverseSense->Update();
+        endCapPolyData->ShallowCopy(reverseSense->GetOutput());
+      }
+    }
+
+    vtkNew<vtkFloatArray> normals;
+    normals->SetName("Normals");
+    normals->SetNumberOfComponents(3);
+    normals->SetNumberOfTuples(endCapPolyData->GetNumberOfPoints());
+    for (int i = 0; i < endCapPolyData->GetNumberOfPoints(); ++i)
+    {
+      normals->SetTuple3(i, planeNormal[0], planeNormal[1], planeNormal[2]);
+    }
+    endCapPolyData->GetPointData()->SetNormals(normals);
+    appendFilter->AddInputData(endCapPolyData);
+  }
+
+  appendFilter->Update();
+  outputEndCap->ShallowCopy(appendFilter->GetOutput());
+
+  if (this->GenerateCellTypeScalars)
+  {
+    this->UpdateCellTypeArray(outputEndCap);
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkCapPolyData::UpdateCellTypeArray(vtkPolyData* polyData)
+{
+  if (!polyData || !polyData->GetCellData())
+  {
+    return;
+  }
+
+  vtkSmartPointer<vtkIdTypeArray> cellTypes = vtkIdTypeArray::SafeDownCast(polyData->GetCellData()->GetArray("CellType"));
+  if (!cellTypes)
+  {
+    cellTypes = vtkSmartPointer<vtkIdTypeArray>::New();
+  }
+
+  cellTypes->SetNumberOfComponents(1);
+  cellTypes->SetNumberOfTuples(polyData->GetNumberOfCells());
+  for (vtkIdType i = 0; i < polyData->GetNumberOfCells(); ++i)
+  {
+    cellTypes->SetValue(i, polyData->GetCellType(i));
+  }
+  cellTypes->SetName("CellType");
+  polyData->GetCellData()->AddArray(cellTypes);
+  polyData->GetCellData()->SetActiveScalars("CellType");
+}
+
+//------------------------------------------------------------------------------
+int vtkCapPolyData::RequestData(vtkInformation* vtkNotUsed(request),
+  vtkInformationVector** inputVector, vtkInformationVector* outputVector)
+{
+  // get the info objects
+  vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+
+  // get the input and output
+  vtkPolyData* input = vtkPolyData::SafeDownCast(inInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkPolyData* output = vtkPolyData::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  vtkDebugMacro(<< "Clipping polygonal data");
+
+  vtkIdType numPts = input->GetNumberOfPoints();
+  vtkPoints* inPts = input->GetPoints();
+  if (numPts < 1 || inPts == nullptr)
+  {
+    vtkDebugMacro(<< "No data to clip");
+    return 1;
+  }
+  if (!this->ClipFunction)
+  {
+    return 1;
+  }
+
+  vtkNew<vtkPlaneCollection> planes;
+  vtkCapPolyData::GetPlanes(this->ClipFunction, planes);
+  vtkCapPolyData::CreateEndCap(planes, input, this->ClipFunction, output);
+
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+// Overload standard modified time function. If Clip functions is modified,
+// then this object is modified as well.
+vtkMTimeType vtkCapPolyData::GetMTime()
+{
+  vtkMTimeType mTime = this->Superclass::GetMTime();
+  vtkMTimeType time;
+
+  if (this->ClipFunction != nullptr)
+  {
+    time = this->ClipFunction->GetMTime();
+    mTime = (time > mTime ? time : mTime);
+  }
+  return mTime;
+}

--- a/vtkCapPolyData.h
+++ b/vtkCapPolyData.h
@@ -1,0 +1,106 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+/**
+ * @class   vtkCapPolyData
+ * @brief   implicit function consisting of boolean combinations of implicit functions, with invert option
+ *
+ * This class is a subclass of vtkPolyDataAlgorithm that will generate an end cap for a polydata cut with the specified function
+ *
+ */
+
+#ifndef vtkCapPolyData_h
+#define vtkCapPolyData_h
+
+ // VTK includes
+#include <vtkAppendPolyData.h>
+#include <vtkImplicitFunction.h>
+#include <vtkPolyDataAlgorithm.h>
+
+// vtkAddon includes
+#include "vtkAddon.h"
+
+class vtkPlaneCollection;
+
+class VTK_ADDON_EXPORT vtkCapPolyData : public vtkPolyDataAlgorithm
+{
+public:
+  vtkTypeMacro(vtkCapPolyData, vtkPolyDataAlgorithm);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+  static vtkCapPolyData* New();
+
+  ///@{
+  /**
+   * Specify the implicit function with which to perform the
+   * clipping. If you do not define an implicit function, then the input
+   * scalar data will be used for clipping.
+   */
+  vtkSetMacro(ClipFunction, vtkSmartPointer<vtkImplicitFunction>);
+  vtkGetMacro(ClipFunction, vtkSmartPointer<vtkImplicitFunction>);
+  ///@}
+
+  /// Return the mtime also considering the locator and clip function.
+  vtkMTimeType GetMTime() override;
+
+  /// Get the list of planes from the implicit function
+  static void GetPlanes(vtkImplicitFunction* function, vtkPlaneCollection* planes, vtkAbstractTransform* parentTransform = nullptr);
+
+  ///@{
+  /**
+   * Set/Get whether to generate an outline of the cap.
+   * Default is on.
+   */
+  vtkSetMacro(GenerateOutline, bool);
+  vtkGetMacro(GenerateOutline, bool);
+  ///@}
+
+  ///@{
+  /**
+   * Set/Get whether to generate cell type scalars.
+   * Default is on.
+   */
+  vtkSetMacro(GenerateCellTypeScalars, bool);
+  vtkGetMacro(GenerateCellTypeScalars, bool);
+  ///@}
+
+protected:
+  vtkCapPolyData();
+  ~vtkCapPolyData() override;
+
+  /// Generate the end cap for the input polydata cut using planes in the cutFunction.
+  void CreateEndCap(vtkPlaneCollection* planes, vtkPolyData* originalPolyData,
+    vtkImplicitFunction* cutFunction, vtkPolyData* outputEndCap);
+
+  /// Updates the polydata cell scalar array to reflect the cell type.
+  void UpdateCellTypeArray(vtkPolyData* polyData);
+
+  int RequestData(vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
+
+protected:
+
+  vtkSmartPointer<vtkImplicitFunction> ClipFunction{ nullptr };
+
+  bool GenerateOutline{ true };
+  bool GenerateCellTypeScalars{ true };
+
+private:
+  vtkCapPolyData(const vtkCapPolyData&) = delete;
+  void operator=(const vtkCapPolyData&) = delete;
+};
+#endif

--- a/vtkImageMathematicsAddon.cxx
+++ b/vtkImageMathematicsAddon.cxx
@@ -1,0 +1,262 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+#include "vtkImageMathematicsAddon.h"
+
+// VTK includes
+#include <vtkAlgorithmOutput.h>
+#include <vtkDataArray.h>
+#include <vtkImageData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
+
+vtkStandardNewMacro(vtkImageMathematicsAddon);
+
+//----------------------------------------------------------------------------
+vtkImageMathematicsAddon::vtkImageMathematicsAddon()
+{
+}
+
+//----------------------------------------------------------------------------
+vtkImageMathematicsAddon::~vtkImageMathematicsAddon()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkImageMathematicsAddon::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//------------------------------------------------------------------------------
+// The output extent is the intersection.
+int vtkImageMathematicsAddon::RequestInformation(vtkInformation* request,
+  vtkInformationVector** inputVector, vtkInformationVector* outputVector)
+{
+  if (this->Operation != VTK_NORMALIZE_MULTIPLY)
+  {
+    return this->Superclass::RequestInformation(request, inputVector, outputVector);
+  }
+
+  // get the info objects
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+  vtkInformation* inInfo;
+
+  int c, idx;
+  int ext[6], unionExt[6];
+
+  // Initialize the union.
+  inInfo = inputVector[0]->GetInformationObject(0);
+  inInfo->Get(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), unionExt);
+
+  // two input take intersection
+  if (this->Operation == VTK_NORMALIZE_MULTIPLY)
+  {
+    for (c = 0; c < this->GetNumberOfInputConnections(0); ++c)
+    {
+      inInfo = inputVector[0]->GetInformationObject(c);
+      inInfo->Get(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), ext);
+      for (idx = 0; idx < 3; ++idx)
+      {
+        if (unionExt[idx * 2] > ext[idx * 2])
+        {
+          unionExt[idx * 2] = ext[idx * 2];
+        }
+        if (unionExt[idx * 2 + 1] < ext[idx * 2 + 1])
+        {
+          unionExt[idx * 2 + 1] = ext[idx * 2 + 1];
+        }
+      }
+    }
+  }
+
+  outInfo->Set(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), unionExt, 6);
+
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+template <class T>
+void vtkImageMathematicsAddonInitOutput(
+  vtkImageData* inData, T* inPtr, vtkImageData* vtkNotUsed(outData), T* outPtr, int ext[6])
+{
+  int idxY, idxZ;
+  int maxY, maxZ;
+  vtkIdType outIncY, outIncZ;
+  int rowLength;
+  int typeSize;
+  T* outPtrZ, * outPtrY;
+  T* inPtrZ, * inPtrY;
+
+  // This method needs to copy scalars from input to output for the update-extent.
+  vtkDataArray* inArray = inData->GetPointData()->GetScalars();
+  typeSize = vtkDataArray::GetDataTypeSize(inArray->GetDataType());
+  outPtrZ = outPtr;
+  inPtrZ = inPtr;
+  // Get increments to march through data
+  vtkIdType increments[3];
+  increments[0] = inArray->GetNumberOfComponents();
+  increments[1] = increments[0] * (ext[1] - ext[0] + 1);
+  increments[2] = increments[1] * (ext[3] - ext[2] + 1);
+  outIncY = increments[1];
+  outIncZ = increments[2];
+
+  // Find the region to loop over
+  rowLength = (ext[1] - ext[0] + 1) * inArray->GetNumberOfComponents();
+  rowLength *= typeSize;
+  maxY = ext[3] - ext[2];
+  maxZ = ext[5] - ext[4];
+
+  // Loop through input pixels
+  for (idxZ = 0; idxZ <= maxZ; idxZ++)
+  {
+    outPtrY = outPtrZ;
+    inPtrY = inPtrZ;
+    for (idxY = 0; idxY <= maxY; idxY++)
+    {
+      memcpy(outPtrY, inPtrY, rowLength);
+      outPtrY += outIncY;
+      inPtrY += outIncY;
+    }
+    outPtrZ += outIncZ;
+    inPtrZ += outIncZ;
+  }
+}
+
+//------------------------------------------------------------------------------
+// This templated function executes the filter for any type of data.
+// Handles the two input operations
+template <class T>
+void vtkImageMathematicsAddonExecute2(vtkImageMathematicsAddon* self, vtkImageData* inData, T* inPtr,
+  vtkImageData* outData, T* outPtr, int outExt[6], int id)
+{
+  int idxR, idxY, idxZ;
+  int maxY, maxZ;
+  vtkIdType inIncX, inIncY, inIncZ;
+  vtkIdType outIncX, outIncY, outIncZ;
+  int rowLength;
+  unsigned long count = 0;
+  unsigned long target;
+  int op = self->GetOperation();
+  int divideByZeroToC = self->GetDivideByZeroToC();
+  double constantc = self->GetConstantC();
+  double normalizeScalarRange[2] = { 0.0, 1.0 };
+  self->GetNormalizeRange(normalizeScalarRange);
+  double normalizeMagnitude = normalizeScalarRange[1] - normalizeScalarRange[0];
+
+  // find the region to loop over
+  rowLength = (outExt[1] - outExt[0] + 1) * inData->GetNumberOfScalarComponents();
+
+  maxY = outExt[3] - outExt[2];
+  maxZ = outExt[5] - outExt[4];
+  target = static_cast<unsigned long>((maxZ + 1) * (maxY + 1) / 50.0);
+  target++;
+
+  // Get increments to march through data
+  inData->GetContinuousIncrements(outExt, inIncX, inIncY, inIncZ);
+  outData->GetContinuousIncrements(outExt, outIncX, outIncY, outIncZ);
+
+  // Loop through output pixels
+  for (idxZ = 0; idxZ <= maxZ; idxZ++)
+  {
+    for (idxY = 0; !self->AbortExecute && idxY <= maxY; idxY++)
+    {
+      if (!id)
+      {
+        if (!(count % target))
+        {
+          self->UpdateProgress(count / (50.0 * target));
+        }
+        count++;
+      }
+      for (idxR = 0; idxR < rowLength; idxR++)
+      {
+        // Pixel operation
+        switch (op)
+        {
+        case VTK_NORMALIZE_MULTIPLY:
+          *outPtr = *inPtr * static_cast<float>((*outPtr - normalizeScalarRange[0]) / normalizeMagnitude);
+          break;
+        default:
+          break;
+        }
+        outPtr++;
+        inPtr++;
+      }
+      outPtr += outIncY;
+      inPtr += inIncY;
+    }
+    outPtr += outIncZ;
+    inPtr += inIncZ;
+  }
+}
+
+//------------------------------------------------------------------------------
+// This method is passed a input and output datas, and executes the filter
+// algorithm to fill the output from the inputs.
+// It just executes a switch statement to call the correct function for
+// the datas data types.
+void vtkImageMathematicsAddon::ThreadedRequestData(vtkInformation* request,
+  vtkInformationVector** inputVector, vtkInformationVector* outputVector,
+  vtkImageData*** inData, vtkImageData** outData, int outExt[6], int id)
+{
+  if (this->Operation != VTK_NORMALIZE_MULTIPLY)
+  {
+    Superclass::ThreadedRequestData(request, inputVector, outputVector, inData, outData, outExt, id);
+    return;
+  }
+
+  void* inPtr1;
+  void* outPtr;
+
+  outPtr = outData[0]->GetScalarPointerForExtent(outExt);
+
+  for (int idx1 = 0; idx1 < this->GetNumberOfInputConnections(0); ++idx1)
+  {
+    inPtr1 = inData[0][idx1]->GetScalarPointerForExtent(outExt);
+    if (this->Operation == VTK_NORMALIZE_MULTIPLY)
+    {
+      if (idx1 == 0)
+      {
+        switch (inData[0][idx1]->GetScalarType())
+        {
+          vtkTemplateMacro(vtkImageMathematicsAddonInitOutput(inData[0][idx1],
+            static_cast<VTK_TT*>(inPtr1), outData[0], static_cast<VTK_TT*>(outPtr), outExt));
+        default:
+          vtkErrorMacro(<< "InitOutput: Unknown ScalarType");
+          return;
+        }
+      }
+      else
+      {
+        switch (inData[0][idx1]->GetScalarType())
+        {
+          vtkTemplateMacro(vtkImageMathematicsAddonExecute2(this, inData[0][idx1],
+            static_cast<VTK_TT*>(inPtr1), outData[0], static_cast<VTK_TT*>(outPtr), outExt, id));
+        default:
+          vtkErrorMacro(<< "Execute: Unknown ScalarType");
+          return;
+        }
+      }
+    }
+  }
+}

--- a/vtkImageMathematicsAddon.h
+++ b/vtkImageMathematicsAddon.h
@@ -1,0 +1,67 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+/**
+ * @class   vtkImageMathematicsAddon
+ * @brief   implicit function consisting of boolean combinations of implicit functions, with invert option
+ *
+ * This class is a subclass of vtkImageMathematics that adds an option to multiply an image by the value of
+ * a second image, normalized using the specified range.
+ */
+
+#ifndef vtkImageMathematicsAddon_h
+#define vtkImageMathematicsAddon_h
+
+#define VTK_NORMALIZE_MULTIPLY 100
+
+// VTK includes
+#include "vtkImageMathematics.h"
+
+// vtkAddon includes
+#include "vtkAddon.h"
+
+class VTK_ADDON_EXPORT vtkImageMathematicsAddon : public vtkImageMathematics
+{
+public:
+  vtkTypeMacro(vtkImageMathematicsAddon, vtkImageMathematics);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+  static vtkImageMathematicsAddon* New();
+
+  void SetOperationToNormalizeMultiply() { this->SetOperation(VTK_NORMALIZE_MULTIPLY); }
+
+  vtkSetVector2Macro(NormalizeRange, double);
+  vtkGetVector2Macro(NormalizeRange, double);
+
+protected:
+  vtkImageMathematicsAddon();
+  ~vtkImageMathematicsAddon() override;
+
+  int RequestInformation(vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
+
+  void ThreadedRequestData(vtkInformation* request, vtkInformationVector** inputVector,
+    vtkInformationVector* outputVector, vtkImageData*** inData, vtkImageData** outData,
+    int outExt[6], int threadId) override;
+
+  double NormalizeRange[2] = { 0.0, 1.0 };
+
+private:
+  vtkImageMathematicsAddon(const vtkImageMathematicsAddon&) = delete;
+  void operator=(const vtkImageMathematicsAddon&) = delete;
+};
+#endif

--- a/vtkImplicitInvertableBoolean.cxx
+++ b/vtkImplicitInvertableBoolean.cxx
@@ -1,0 +1,66 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+#include "vtkImplicitInvertableBoolean.h"
+#include "vtkObjectFactory.h"
+
+vtkStandardNewMacro(vtkImplicitInvertableBoolean);
+
+//----------------------------------------------------------------------------
+vtkImplicitInvertableBoolean::vtkImplicitInvertableBoolean()
+{
+  this->Invert = false;
+}
+
+//----------------------------------------------------------------------------
+vtkImplicitInvertableBoolean::~vtkImplicitInvertableBoolean()
+{
+}
+
+//----------------------------------------------------------------------------
+double vtkImplicitInvertableBoolean::EvaluateFunction(double x[3])
+{
+  double value = Superclass::EvaluateFunction(x);
+  if (this->Invert)
+  {
+    value = -value;
+  }
+  return value;
+}
+
+//----------------------------------------------------------------------------
+void vtkImplicitInvertableBoolean::EvaluateGradient(double x[3], double g[3])
+{
+  Superclass::EvaluateGradient(x, g);
+  if (this->Invert)
+  {
+    g[0] = -g[0];
+    g[1] = -g[1];
+    g[2] = -g[2];
+  }
+}
+
+//----------------------------------------------------------------------------
+void vtkImplicitInvertableBoolean::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  os << indent << "Invert:\n";
+  os << indent << (this->Invert ? "True" : "False") << "\n";
+}

--- a/vtkImplicitInvertableBoolean.h
+++ b/vtkImplicitInvertableBoolean.h
@@ -1,0 +1,75 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+/**
+ * @class   vtkImplicitInvertableBoolean
+ * @brief   implicit function consisting of boolean combinations of implicit functions, with invert option
+ *
+ * This class is a subclass of vtkImplicitBoolean that adds an option to invert the result of the boolean operation.
+ * 
+ */
+
+#ifndef vtkImplicitInvertableBoolean_h
+#define vtkImplicitInvertableBoolean_h
+
+// VTK includes
+#include "vtkImplicitBoolean.h"
+
+// vtkAddon includes
+#include "vtkAddon.h"
+
+class VTK_ADDON_EXPORT vtkImplicitInvertableBoolean : public vtkImplicitBoolean
+{
+public:
+  vtkTypeMacro(vtkImplicitInvertableBoolean, vtkImplicitBoolean);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+  static vtkImplicitInvertableBoolean* New();
+
+  ///@{
+  /**
+   * Evaluate boolean combinations of implicit function using current operator.
+   */
+  double EvaluateFunction(double x[3]) override;
+  ///@}
+
+  /**
+   * Evaluate gradient of boolean combination.
+   */
+  void EvaluateGradient(double x[3], double g[3]) override;
+
+  ///@{
+  /**
+   * Specify if the resulting function should be inverted
+   */
+  vtkSetMacro(Invert, bool);
+  vtkGetMacro(Invert, bool);
+  vtkBooleanMacro(Invert, bool);
+  ///@}
+
+protected:
+  vtkImplicitInvertableBoolean();
+  ~vtkImplicitInvertableBoolean() override;
+
+  bool Invert;
+
+private:
+  vtkImplicitInvertableBoolean(const vtkImplicitInvertableBoolean&) = delete;
+  void operator=(const vtkImplicitInvertableBoolean&) = delete;
+};
+#endif


### PR DESCRIPTION
Adds the following classes used to support node clipping in 3D Slicer:
- vtkCapPolyData: Generate a surface cap for all plane cutting nodes in the specified vtkImplicitFunction
- vtkImageMathematicsAddon: Subclass of vtkImageMathematics that adds the additional option to multiply image A with the normalized voxel contents of image B.
- vtkImplicitInvertableBoolean: Subclass of vtkImplicitBoolean that can invert the sign of the function, turning it inside out.