### PR TITLE
COMP: Update to newer find_package(Python3) support

### DIFF
--- a/CMake/vtkMacroKitPythonWrap.cmake
+++ b/CMake/vtkMacroKitPythonWrap.cmake
@@ -160,7 +160,7 @@ macro(vtkMacroKitPythonWrap)
 
   if(VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
 
-    # Tell vtkWrapPython.cmake to set VTK_PYTHON_LIBRARIES for us.
+    # Tell vtkWrapPython.cmake to set VTK_Python3_LIBRARIES for us.
     set(VTK_WRAP_PYTHON_FIND_LIBS 1)
     include(vtkWrapPython)
 
@@ -283,7 +283,7 @@ macro(vtkMacroKitPythonWrap)
       ${MY_KIT_NAME}PythonD
       ${MY_KIT_NAME}
       ${VTK_PYTHON_CORE}
-      ${VTK_PYTHON_LIBRARIES}
+      ${VTK_Python3_LIBRARIES}
       ${VTK_KIT_PYTHON_LIBRARIES}
       ${MY_KIT_PYTHON_LIBRARIES}
       )
@@ -344,7 +344,7 @@ macro(vtkMacroKitPythonWrap)
     target_link_libraries(${MY_KIT_NAME}Python
       PRIVATE
         ${MY_KIT_NAME}
-        ${VTK_PYTHON_LIBRARIES}
+        ${VTK_Python3_LIBRARIES}
         VTK::WrappingPythonCore
         VTK::Python
         )

--- a/CMake/vtkWrapPython.cmake
+++ b/CMake/vtkWrapPython.cmake
@@ -189,14 +189,14 @@ if(VTK_WRAP_PYTHON_FIND_LIBS)
   else()
     set(_QUIET_LIBRARY "REQUIRED")
   endif()
-  find_package(PythonLibs ${_QUIET_LIBRARY})
+  find_package(Python3 COMPONENTS Development ${_QUIET_LIBRARY})
 
   # Use separate debug/optimized libraries if they are different.
   if(PYTHON_DEBUG_LIBRARY)
     if("${PYTHON_DEBUG_LIBRARY}" STREQUAL "${PYTHON_LIBRARY}")
-      set(VTK_PYTHON_LIBRARIES ${PYTHON_LIBRARY})
+      set(VTK_Python3_LIBRARIES ${PYTHON_LIBRARY})
     else()
-      set(VTK_PYTHON_LIBRARIES
+      set(VTK_Python3_LIBRARIES
         optimized ${PYTHON_LIBRARY}
         debug ${PYTHON_DEBUG_LIBRARY})
     endif()
@@ -207,7 +207,7 @@ if(VTK_WRAP_PYTHON_FIND_LIBS)
       endif()
     endif()
   else()
-    set(VTK_PYTHON_LIBRARIES ${PYTHON_LIBRARY})
+    set(VTK_Python3_LIBRARIES ${PYTHON_LIBRARY})
   endif()
 
   # Some python installations on UNIX need to link to extra libraries
@@ -224,7 +224,7 @@ if(VTK_WRAP_PYTHON_FIND_LIBS)
   endif()
 
   # Include any extra libraries for python.
-  set(VTK_PYTHON_LIBRARIES ${VTK_PYTHON_LIBRARIES} ${PYTHON_EXTRA_LIBS})
+  set(VTK_Python3_LIBRARIES ${VTK_Python3_LIBRARIES} ${PYTHON_EXTRA_LIBS})
 endif()
 
 # Determine the location of the supplied header in the include_dirs supplied.

--- a/Testing/vtkParallelTransportTest1.cxx
+++ b/Testing/vtkParallelTransportTest1.cxx
@@ -35,7 +35,6 @@ int vtkParallelTransportTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 
   // Test computation with a straight line input (zero curvature)
 
-  double lineDirection[3] = { 0.0, 0.0, 1.0 };
   vtkNew<vtkLineSource> line;
   line->SetPoint1(10,20,30);
   line->SetPoint1(30,70,-80);
@@ -97,7 +96,6 @@ int vtkParallelTransportTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
     vtkPointData* pointData = parallelTransportFrame->GetOutput()->GetPointData();
     vtkDoubleArray* normalsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Normals"));
     vtkDoubleArray* binormalsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Binormals"));
-    vtkDoubleArray* tangentsArray = vtkDoubleArray::SafeDownCast(pointData->GetArray("Tangents"));
     double constantBinormal[3] = { 0.0, 0.0, 0.0 };
     binormalsArray->GetTypedTuple(0, constantBinormal);
     for (vtkIdType tupleIndex = 1; tupleIndex < normalsArray->GetNumberOfTuples(); tupleIndex++)


### PR DESCRIPTION
The Python3 cmake find_package module was first added in version 3.12
This module provides more rigorous support for specifying
the exact version and components that are needed.  The module
has refinements in newer cmake versions to limit the
version and specify the ABI required.