### PR TITLE
ENH: Add "Commit Message Check" GitHub workflow

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,24 @@
+name: "Commit Message Check"
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Commit Message
+        uses: Slicer/slicer-check-commit-message-action@26db1d4a0580194025a00bff6f5c24a88c0efb9f # v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Verifies that commit messages conform to the Slicer commit style guidelines using https://github.com/Slicer/slicer-check-commit-message-action