### PR TITLE
COMP: Fix encoding warning (non-UTF-8 character)

### DIFF
--- a/vtkParallelTransportFrame.h
+++ b/vtkParallelTransportFrame.h
@@ -26,7 +26,7 @@
 ///
 /// References:
 /// - Parallel transport theory: R. Bishop, "There is more than one way to frame a curve",
-///   American Mathematical Monthly, vol. 82, no. 3, pp. 246–251, 1975
+///   American Mathematical Monthly, vol. 82, no. 3, pp. 246-251, 1975
 /// - Parallel transport implementation: Piccinelli M, Veneziani A, Steinman DA, Remuzzi A, Antiga L.
 ///   "A framework for geometric analysis of vascular structures: application to cerebral aneurysms.",
 ///   IEEE Trans Med Imaging. 2009 Aug;28(8):1141-55. doi: 10.1109/TMI.2009.2021652.


### PR DESCRIPTION
During Slicer superbuild, Visual C++ complains about a character not valid for codepage 65001 (UTF-8).

It's in the comments only, but I'm thinking less warnings is always good ;)