### PR TITLE
COMP: Include the iostream header where cout/cerr used

### DIFF
--- a/Testing/vtkAddonTestingUtilitiesTest1.cxx
+++ b/Testing/vtkAddonTestingUtilitiesTest1.cxx
@@ -21,6 +21,9 @@
 // vtkAddon includes
 #include "vtkAddonTestingUtilities.h"
 
+// STD includes
+#include <iostream>
+
 using namespace vtkAddonTestingUtilities;
 
 //----------------------------------------------------------------------------

--- a/Testing/vtkParallelTransportTest1.cxx
+++ b/Testing/vtkParallelTransportTest1.cxx
@@ -26,6 +26,9 @@
 #include <vtkNew.h>
 #include <vtkPointData.h>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 int vtkParallelTransportTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 {
@@ -87,7 +90,7 @@ int vtkParallelTransportTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   arc->GetOutput()->GetPoint(0, arcFirstPoint);
   double preferredNormalDirection[3] = { arcCenter[0] - arcFirstPoint[0], arcCenter[1] - arcFirstPoint[1], arcCenter[2] - arcFirstPoint[2] };
   parallelTransportFrame->SetPreferredInitialNormalVector(preferredNormalDirection);
-  
+
   parallelTransportFrame->SetInputConnection(arc->GetOutputPort());
   parallelTransportFrame->Update();
 

--- a/vtkTestingOutputWindow.h
+++ b/vtkTestingOutputWindow.h
@@ -22,6 +22,9 @@
 #include "vtkOutputWindow.h"
 #include "vtkLoggingMacros.h" // for vtkInfoWithoutObjectMacro
 
+// STD includes
+#include <iostream>
+
 /// \brief VTK message output window class for automated testing.
 ///
 /// This is a VTK output window class that is optimized to be used
@@ -51,7 +54,7 @@ public:
   /* Explicitly deleted functions belong in the public interface */
   vtkTestingOutputWindow(const vtkTestingOutputWindow&) = delete;
   void operator=(const vtkTestingOutputWindow&) = delete;
-  
+
   // Gets a pointer to the singleton testing output window instance.
   // If the current VTK output window is not vtkTestingOutputWindow type then
   // it changes the output window to that.
@@ -67,11 +70,11 @@ public:
 
   // Sets number of warning and error messages to zero
   virtual void ResetNumberOfLoggedMessages();
-  
+
   // Number of any logged messages
   vtkGetMacro(NumberOfLoggedMessages, int);
   vtkSetMacro(NumberOfLoggedMessages, int);
-  
+
   // Number of logged warning or generic warning messages
   vtkGetMacro(NumberOfLoggedWarningMessages, int);
   vtkSetMacro(NumberOfLoggedWarningMessages, int);
@@ -79,14 +82,14 @@ public:
   // Number of logged error messages
   vtkGetMacro(NumberOfLoggedErrorMessages, int);
   vtkSetMacro(NumberOfLoggedErrorMessages, int);
-  
+
   // Returns the sum of warning and error messages logged
   int GetNumberOfLoggedWarningErrorMessages();
-  
+
 protected:
-  vtkTestingOutputWindow(); 
-  ~vtkTestingOutputWindow() override; 
-  
+  vtkTestingOutputWindow();
+  ~vtkTestingOutputWindow() override;
+
   int NumberOfLoggedWarningMessages{0};
   int NumberOfLoggedErrorMessages{0};
   int NumberOfLoggedMessages{0};


### PR DESCRIPTION
This change is necessary to be compatible with VTK 9.6 code as iostream was removed from a core header file as seen in https://github.com/Kitware/VTK/commit/a95326aef076dd9fc6d7329d5fb54f1015ca59b9. See release note https://github.com/Kitware/VTK/commit/7462a8b1411a78f470ca459a34cf1ef2e7c353a8.

See the announcement made on the VTK discourse about this update https://discourse.vtk.org/t/important-update-standard-iostream-availability-from-vtk/16171.
