### PR TITLE
Make vtkAddon installable and remove link of Python library

### DIFF
--- a/CMake/vtkMacroKitPythonWrap.cmake
+++ b/CMake/vtkMacroKitPythonWrap.cmake
@@ -159,9 +159,6 @@ macro(vtkMacroKitPythonWrap)
   endif()
 
   if(VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
-
-    # Tell vtkWrapPython.cmake to set VTK_Python3_LIBRARIES for us.
-    set(VTK_WRAP_PYTHON_FIND_LIBS 1)
     include(vtkWrapPython)
 
     set(TMP_WRAP_FILES ${MY_KIT_SRCS} ${MY_KIT_WRAP_HEADERS})
@@ -283,7 +280,6 @@ macro(vtkMacroKitPythonWrap)
       ${MY_KIT_NAME}PythonD
       ${MY_KIT_NAME}
       ${VTK_PYTHON_CORE}
-      ${VTK_Python3_LIBRARIES}
       ${VTK_KIT_PYTHON_LIBRARIES}
       ${MY_KIT_PYTHON_LIBRARIES}
       )
@@ -344,7 +340,6 @@ macro(vtkMacroKitPythonWrap)
     target_link_libraries(${MY_KIT_NAME}Python
       PRIVATE
         ${MY_KIT_NAME}
-        ${VTK_Python3_LIBRARIES}
         VTK::WrappingPythonCore
         VTK::Python
         )

--- a/CMake/vtkWrapPython.cmake
+++ b/CMake/vtkWrapPython.cmake
@@ -183,48 +183,7 @@ $<$<BOOL:$<TARGET_PROPERTY:${TARGET},INCLUDE_DIRECTORIES>>:
 endmacro()
 
 if(VTK_WRAP_PYTHON_FIND_LIBS)
-  get_filename_component(_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-  if (VTK_UNDEFINED_SYMBOLS_ALLOWED)
-    set(_QUIET_LIBRARY "QUIET")
-  else()
-    set(_QUIET_LIBRARY "REQUIRED")
-  endif()
-  find_package(Python3 COMPONENTS Development ${_QUIET_LIBRARY})
-
-  # Use separate debug/optimized libraries if they are different.
-  if(PYTHON_DEBUG_LIBRARY)
-    if("${PYTHON_DEBUG_LIBRARY}" STREQUAL "${PYTHON_LIBRARY}")
-      set(VTK_Python3_LIBRARIES ${PYTHON_LIBRARY})
-    else()
-      set(VTK_Python3_LIBRARIES
-        optimized ${PYTHON_LIBRARY}
-        debug ${PYTHON_DEBUG_LIBRARY})
-    endif()
-    set(VTK_WINDOWS_PYTHON_DEBUGGABLE 0)
-    if(WIN32)
-      if(PYTHON_DEBUG_LIBRARY MATCHES "_d")
-        set(VTK_WINDOWS_PYTHON_DEBUGGABLE 1)
-      endif()
-    endif()
-  else()
-    set(VTK_Python3_LIBRARIES ${PYTHON_LIBRARY})
-  endif()
-
-  # Some python installations on UNIX need to link to extra libraries
-  # such as zlib (-lz).  It is hard to automatically detect the needed
-  # libraries so instead just give the user an easy way to specify
-  # the libraries.  This should be needed only rarely.  It should
-  # also be moved to the CMake FindPython.cmake module at some point.
-  if(UNIX)
-    if(NOT DEFINED PYTHON_EXTRA_LIBS)
-      set(PYTHON_EXTRA_LIBS "" CACHE STRING
-        "Extra libraries to link when linking to python (such as \"z\" for zlib).  Separate multiple libraries with semicolons.")
-      mark_as_advanced(PYTHON_EXTRA_LIBS)
-    endif()
-  endif()
-
-  # Include any extra libraries for python.
-  set(VTK_Python3_LIBRARIES ${VTK_Python3_LIBRARIES} ${PYTHON_EXTRA_LIBS})
+  find_package(Python3 COMPONENTS Development.Module REQUIRED)
 endif()
 
 # Determine the location of the supplied header in the include_dirs supplied.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,20 @@ include(vtkAddonFunctionAddExecutable)
 #
 # VTK
 #
-find_package(VTK REQUIRED)
+set(vtkAddon_VTK_COMPONENTS
+  CommonComputationalGeometry
+  FiltersModeling
+  FiltersHybrid
+  FiltersSources
+  ImagingGeneral
+  RenderingOpenGL2
+  RenderingVolumeOpenGL2
+  eigen
+)
+if(vtkAddon_WRAP_PYTHON)
+  list(APPEND vtkAddon_VTK_COMPONENTS Python)
+endif()
+find_package(VTK REQUIRED COMPONENTS ${vtkAddon_VTK_COMPONENTS})
 if(${VTK_VERSION} VERSION_LESS "8.90")
   include(${VTK_USE_FILE})
 endif()
@@ -60,34 +73,13 @@ configure_file(
   )
 
 # --------------------------------------------------------------------------
-# Install headers
-# --------------------------------------------------------------------------
-
-if(NOT DEFINED ${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT)
-  set(${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT ON)
-endif()
-
-if(NOT ${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT)
-
-  if(NOT DEFINED ${PROJECT_NAME}_INSTALL_INCLUDE_DIR)
-    set(${PROJECT_NAME}_INSTALL_INCLUDE_DIR include/${PROJECT_NAME})
-  endif()
-
-  file(GLOB headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
-  install(
-    FILES ${headers} ${CMAKE_CURRENT_BINARY_DIR}/${configure_header_file}
-    DESTINATION ${${PROJECT_NAME}_INSTALL_INCLUDE_DIR} COMPONENT Development)
-
-  file(GLOB headers "${CMAKE_CURRENT_SOURCE_DIR}/*.txx")
-  install(
-    FILES ${headers} ${CMAKE_CURRENT_BINARY_DIR}/${configure_header_file}
-    DESTINATION ${${PROJECT_NAME}_INSTALL_INCLUDE_DIR} COMPONENT Development)
-endif()
-
-# --------------------------------------------------------------------------
 # Sources
 # --------------------------------------------------------------------------
 set(vtkAddon_SRCS
+  vtkAddon.h
+  ${CMAKE_CURRENT_BINARY_DIR}/${configure_header_file}
+  vtkAddonExport.h
+  vtkAddonTestingMacros.h
   vtkAddonMathUtilities.cxx
   vtkAddonMathUtilities.h
   vtkAddonSetGet.h
@@ -157,14 +149,6 @@ set_source_files_properties(
   vtkLoggingMacros.h
   WRAP_EXCLUDE
   )
-# --------------------------------------------------------------------------
-# Include dirs
-# --------------------------------------------------------------------------
-set(include_dirs
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-  )
-include_directories(BEFORE ${include_dirs})
 
 # --------------------------------------------------------------------------
 # Build library
@@ -175,6 +159,11 @@ set(srcs ${vtkAddon_SRCS})
 add_library(${lib_name} ${srcs})
 
 target_link_libraries(${lib_name} ${vtkAddon_LIBS})
+target_include_directories(${lib_name} BEFORE PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 
 # --------------------------------------------------------------------------
 # Folder
@@ -207,6 +196,7 @@ if(NOT DEFINED ${PROJECT_NAME}_INSTALL_LIB_DIR)
 endif()
 
 install(TARGETS ${lib_name}
+  EXPORT vtkAddonTargets
   RUNTIME DESTINATION ${${PROJECT_NAME}_INSTALL_BIN_DIR} COMPONENT RuntimeLibraries
   LIBRARY DESTINATION ${${PROJECT_NAME}_INSTALL_LIB_DIR} COMPONENT RuntimeLibraries
   ARCHIVE DESTINATION ${${PROJECT_NAME}_INSTALL_LIB_DIR} COMPONENT Development
@@ -272,28 +262,57 @@ set(${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BIN
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/vtkAddonConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/vtkAddonConfig.cmake
-  )
-
-# Configuret vtkAddonConfig.cmake for an install tree
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/vtkAddonInstallConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/install/vtkAddonConfig.cmake
+  @ONLY
   )
 
 # --------------------------------------------------------------------------
-# Install configuration files
+# Install development files
 # --------------------------------------------------------------------------
 
-# Set vtkAddon_INSTALL_CMAKE_DIR
-if(NOT DEFINED ${PROJECT_NAME}_INSTALL_CMAKE_DIR)
-  set(${PROJECT_NAME}_INSTALL_CMAKE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
+if(NOT DEFINED ${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT)
+  set(${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT ON)
 endif()
 
-# Install vtkAddonConfig.cmake
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/install/vtkAddonConfig.cmake
-  DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKE_DIR}
-  )
+if(NOT DEFINED ${PROJECT_NAME}_INSTALL_INCLUDE_DIR)
+  set(${PROJECT_NAME}_INSTALL_INCLUDE_DIR "include/${PROJECT_NAME}")
+endif()
+
+if(NOT DEFINED ${PROJECT_NAME}_INSTALL_CMAKE_DIR)
+  # uses one of find_package universal prefix by default
+  set(${PROJECT_NAME}_INSTALL_CMAKE_DIR "${PROJECT_NAME}/lib/cmake/${PROJECT_NAME}")
+endif()
+
+if(NOT ${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT)
+  # Install vtkAddon headers, uses a pattern because they are not explicitly listed
+  set(vtkAddon_HEADERS ${vtkAddon_SRCS})
+  list(FILTER vtkAddon_HEADERS INCLUDE REGEX ".*\\.(h|txx)$")
+  install(
+    FILES ${vtkAddon_HEADERS}
+    DESTINATION "${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}"
+    COMPONENT Development
+    )
+
+  # Configure vtkAddonInstallConfig.cmake for the install tree
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/vtkAddonInstallConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/install/vtkAddonConfig.cmake
+    INSTALL_DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKE_DIR}"
+    )
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/install/vtkAddonConfig.cmake
+    DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKE_DIR}"
+    COMPONENT Development
+    )
+
+  install(
+    EXPORT vtkAddonTargets
+    FILE ${PROJECT_NAME}Targets.cmake
+    DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKE_DIR}"
+    COMPONENT Development
+    )
+endif()
 
 # Install vtkAddon CMake files
 install(
@@ -305,5 +324,6 @@ install(
   ${CMAKE_SOURCE_DIR}/CMake/vtkWrapperInit.data.in
   ${CMAKE_SOURCE_DIR}/CMake/vtkWrapPython.cmake
   ${CMAKE_SOURCE_DIR}/CMake/WindowsApplicationUseUtf8.manifest
-  DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKE_DIR} COMPONENT Development
+  DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKE_DIR}"
+  COMPONENT Development
   )

--- a/vtkAddonInstallConfig.cmake.in
+++ b/vtkAddonInstallConfig.cmake.in
@@ -1,6 +1,12 @@
-set(vtkAddon_CMAKE_DIR "@CMAKE_INSTALL_PREFIX@/@vtkAddon_INSTALL_CMAKE_DIR@")
-set(vtkAddon_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/@vtkAddon_INSTALL_INCLUDE_DIR@")
-set(vtkAddon_LIB_DIR "@CMAKE_INSTALL_PREFIX@/@vtkAddon_INSTALL_LIB_DIR@")
-set(VTK_DIR "@VTK_DIR@")
+# PACKAGE_PREFIX_DIR will be defined by generated code below
+@PACKAGE_INIT@
 
+include("${CMAKE_CURRENT_LIST_DIR}/vtkAddonTargets.cmake")
+
+include(CMakeFindDependencyMacro)
+find_dependency(VTK COMPONENTS @vtkAddon_VTK_COMPONENTS@)
 set(vtkAddon_USE_UTF8 "@vtkAddon_USE_UTF8@")
+
+set(vtkAddon_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+set(vtkAddon_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@vtkAddon_INSTALL_INCLUDE_DIR@")
+set(vtkAddon_LIB_DIR "${PACKAGE_PREFIX_DIR}/@vtkAddon_INSTALL_LIB_DIR@")


### PR DESCRIPTION
This PR contains all changes that I needed to make slicer-core package-able without too much effort.

- Remove link against Python Development.Embed component (libpython) and associated find_package, variables...
- Make install tree relocatable
- Add missing files to ensure install tree contains them

related to #27 

@lassoan @jamesobutler  @Thibault-Pelletier @finetjul 