### PR TITLE
ENH: avoid double negation variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,8 +274,24 @@ configure_file(
 # Install development files
 # --------------------------------------------------------------------------
 
-if(NOT DEFINED ${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT)
-  set(${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT ON)
+# Install the development files (headers, CMake package config, exported
+# targets) in addition to the runtime library. OFF by default so a plain
+# install ships only the runtime; turn ON for packaging / standalone install
+# trees. (CMP0077 is NEW at this cmake_minimum_required, so a parent project may
+# still override this before add_subdirectory().)
+option(${PROJECT_NAME}_INSTALL_DEVELOPMENT
+  "Install ${PROJECT_NAME} development files (headers, CMake package config, exported targets)" OFF)
+
+# Backward compatibility: honor the deprecated, inverted
+# ${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT if a consumer still sets it.
+if(DEFINED ${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT)
+  message(DEPRECATION
+    "${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT is deprecated; use ${PROJECT_NAME}_INSTALL_DEVELOPMENT (inverted value).")
+  if(${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT)
+    set(${PROJECT_NAME}_INSTALL_DEVELOPMENT OFF CACHE BOOL "" FORCE)
+  else()
+    set(${PROJECT_NAME}_INSTALL_DEVELOPMENT ON CACHE BOOL "" FORCE)
+  endif()
 endif()
 
 if(NOT DEFINED ${PROJECT_NAME}_INSTALL_CMAKE_DIR)
@@ -283,7 +299,7 @@ if(NOT DEFINED ${PROJECT_NAME}_INSTALL_CMAKE_DIR)
   set(${PROJECT_NAME}_INSTALL_CMAKE_DIR "${PROJECT_NAME}/lib/cmake/${PROJECT_NAME}")
 endif()
 
-if(NOT ${PROJECT_NAME}_INSTALL_NO_DEVELOPMENT)
+if(${PROJECT_NAME}_INSTALL_DEVELOPMENT)
   # Install vtkAddon headers, uses a pattern because they are not explicitly listed
   set(vtkAddon_HEADERS ${vtkAddon_SRCS})
   list(FILTER vtkAddon_HEADERS INCLUDE REGEX ".*\\.(h|txx)$")

--- a/README.md
+++ b/README.md
@@ -31,6 +31,33 @@ In September 2020, support for VTK versions earlier than 8.2 was removed ([a64d8
 and compatibility with VTK 8.90 and newer was added ([4a3a79b3](https://github.com/Slicer/vtkAddon/pull/12/commits/4a3a79b3d4ffbc39a33a6803f8da80a94bb270c6))
 to align with modern VTK development practices.
 
+## Installing / packaging
+
+By default only the runtime library is installed. To also install the
+development files (headers, exported CMake targets and the package config
+file) — e.g. when building a package or a standalone install tree — turn on
+`vtkAddon_INSTALL_DEVELOPMENT`:
+
+    cmake -DvtkAddon_INSTALL_DEVELOPMENT=ON -DCMAKE_INSTALL_PREFIX=/path/to/prefix ../vtkAddon
+    make install
+
+The install tree is relocatable. Downstream projects consume it with:
+
+    find_package(vtkAddon REQUIRED)
+    target_link_libraries(MyTarget PRIVATE vtkAddon)
+
+The following variables let a parent project (typically a superbuild) override
+the install layout; each defaults to a standalone-friendly value when unset:
+
+| Variable                       | Default            |
+|--------------------------------|--------------------|
+| `vtkAddon_INSTALL_DEVELOPMENT` | `OFF`              |
+| `vtkAddon_INSTALL_BIN_DIR`     | `bin`              |
+| `vtkAddon_INSTALL_LIB_DIR`     | `lib/vtkAddon`     |
+| `vtkAddon_INSTALL_INCLUDE_DIR` | `include/vtkAddon` |
+| `vtkAddon_INSTALL_CMAKE_DIR`   | `cmake/vtkAddon`   |
+
+
 ## License
 
 This project is distributed under the BSD-style Slicer license allowing academic and commercial use without any restrictions. Please see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Fixes https://github.com/Slicer/vtkAddon/issues/72

Copy-pasted verbatim from @RafaelPalomar at https://github.com/commontk/qRestAPI/pull/28/, to be consistent according to lassoan's suggestion in that PR

fyi @pieper @lassoan

Note that 3DSlicer already follows this approach of option rather than the legacy double-negation