### PR TITLE
COMP: Link the full Python library for wrapped modules where required

### DIFF
--- a/CMake/vtkMacroKitPythonWrap.cmake
+++ b/CMake/vtkMacroKitPythonWrap.cmake
@@ -159,6 +159,7 @@ macro(vtkMacroKitPythonWrap)
   endif()
 
   if(VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
+    set(VTK_WRAP_PYTHON_FIND_LIBS 1)
     include(vtkWrapPython)
 
     set(TMP_WRAP_FILES ${MY_KIT_SRCS} ${MY_KIT_WRAP_HEADERS})
@@ -280,6 +281,7 @@ macro(vtkMacroKitPythonWrap)
       ${MY_KIT_NAME}PythonD
       ${MY_KIT_NAME}
       ${VTK_PYTHON_CORE}
+      ${VTK_Python3_LIBRARIES}
       ${VTK_KIT_PYTHON_LIBRARIES}
       ${MY_KIT_PYTHON_LIBRARIES}
       )
@@ -340,6 +342,7 @@ macro(vtkMacroKitPythonWrap)
     target_link_libraries(${MY_KIT_NAME}Python
       PRIVATE
         ${MY_KIT_NAME}
+        ${VTK_Python3_LIBRARIES}
         VTK::WrappingPythonCore
         VTK::Python
         )

--- a/CMake/vtkWrapPython.cmake
+++ b/CMake/vtkWrapPython.cmake
@@ -233,7 +233,18 @@ $<$<BOOL:$<TARGET_PROPERTY:${TARGET},INCLUDE_DIRECTORIES>>:
 endmacro()
 
 if(VTK_WRAP_PYTHON_FIND_LIBS)
-  find_package(Python3 COMPONENTS Development.Module REQUIRED)
+  # Development.Module leaves the Python C-API symbols undefined for the host
+  # interpreter to provide. That is fine where the linker allows undefined
+  # symbols (macOS -undefined dynamic_lookup), but on Linux the wrapped modules
+  # link with -Wl,--no-undefined and must resolve the Python symbols at link
+  # time, so the full library (Python3::Python) is required there.
+  if(VTK_UNDEFINED_SYMBOLS_ALLOWED)
+    find_package(Python3 COMPONENTS Development.Module REQUIRED)
+    set(VTK_Python3_LIBRARIES "")
+  else()
+    find_package(Python3 COMPONENTS Development REQUIRED)
+    set(VTK_Python3_LIBRARIES Python3::Python)
+  endif()
 endif()
 
 # Determine the location of the supplied header in the include_dirs supplied.


### PR DESCRIPTION
cc @AlexyPellegrini

## Problem

This is the root cause of the current Linux build breakage in Slicer ([Slicer/Slicer#9348](https://github.com/Slicer/Slicer/issues/9348)), which appeared after the SuperBuild vtkAddon bump.

`c44ce00` ("COMP: Only search for Python3 Development.Module component") did three coupled things:
1. switched `find_package(Python3 COMPONENTS Development)` → `Development.Module`,
2. removed `set(VTK_WRAP_PYTHON_FIND_LIBS 1)` in `vtkMacroKitPythonWrap.cmake` (so the "find the Python library" block in `vtkWrapPython.cmake` became dead and `VTK_Python3_LIBRARIES` is never set), and
3. removed `${VTK_Python3_LIBRARIES}` from both `target_link_libraries` calls for the wrapped module.

`Development.Module` provides only `Python3::Module`, which deliberately leaves the Python C-API symbols undefined for the host interpreter to supply. That is fine where the linker allows undefined symbols (on macOS, `MODULE` targets link with `-undefined dynamic_lookup`), but on Linux the wrapped modules are linked with `-Wl,--no-undefined` (`vtk_undefined_symbols_allowed=FALSE`) and must resolve the Python symbols at link time. The result is a link failure of every wrapped module:

```
vtkAddonMathUtilitiesPython.cxx: undefined reference to `PyTuple_Size'
```

## Fix

Restore what the removed code provided, gated on `VTK_UNDEFINED_SYMBOLS_ALLOWED`: keep `Development.Module` where undefined symbols are allowed, otherwise require the full `Development` component and link `Python3::Python`. `VTK_WRAP_PYTHON_FIND_LIBS` is set again so the block runs, and `VTK_Python3_LIBRARIES` is re-added to the wrapped-module link line (both the VTK<8.90 and VTK>=8.90 paths).

@AlexyPellegrini — since the `Development.Module` switch was intentional, flagging in case you'd prefer instead to exempt the wrapped `MODULE` targets from `-Wl,--no-undefined` (the way VTK's own module wrapper does). This PR takes the more conservative "restore the prior linkage" route to unbreak the dashboards.

## Testing

Reproduced and fixed on an Ubuntu 22.04 Slicer superbuild (Release, VTK 9.6, Python 3.12): without the change the inner build fails linking the wrapped Python modules; with it, the full application builds, packages, and runs off the build machine — the previously-failing classes (`vtkAddonMathUtilities`, `vtkSegmentation`, …) load, and inherited base-class methods (`vtkOrientedGridTransform.SetDisplacementGridData`) are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)